### PR TITLE
Feat/optimizations

### DIFF
--- a/src/lib/helpers/logger.ts
+++ b/src/lib/helpers/logger.ts
@@ -20,7 +20,7 @@ class Logger {
         private readonly logStyle: Record<ELogLevel, LevelStyle>
     ) { }
 
-    public verbosity = ELogLevel.INFO;
+    public verbosity = ELogLevel.WARN;
 
     public readonly warn = this.log.bind(this, ELogLevel.WARN);
     public readonly info = this.log.bind(this, ELogLevel.INFO);

--- a/src/lib/helpers/logger.ts
+++ b/src/lib/helpers/logger.ts
@@ -18,7 +18,7 @@ class Logger {
     public constructor(
         private readonly prefix: string,
         private readonly logStyle: Record<ELogLevel, LevelStyle>
-    ) { }
+    ) {}
 
     public verbosity = ELogLevel.WARN;
 

--- a/src/lib/helpers/logger.ts
+++ b/src/lib/helpers/logger.ts
@@ -1,0 +1,42 @@
+enum EVerbosity {
+    WARN = 0,
+    INFO,
+    DEBUG,
+    DIAGNOSTIC,
+}
+
+class Logger {
+    private static readonly prefix = 'aresrpg-engine: ';
+    public verbosity = EVerbosity.INFO;
+
+    public warn(message: string): void {
+        if (this.verbosity >= EVerbosity.WARN) {
+            console.warn(Logger.prefix + message);
+        }
+    }
+
+    public info(message: string): void {
+        if (this.verbosity >= EVerbosity.INFO) {
+            console.info(Logger.prefix + message);
+        }
+    }
+
+    public debug(message: string): void {
+        if (this.verbosity >= EVerbosity.DEBUG) {
+            console.debug(Logger.prefix + message);
+        }
+    }
+
+    public diagnostic(message: string): void {
+        if (this.verbosity >= EVerbosity.DIAGNOSTIC) {
+            console.debug(Logger.prefix + message);
+        }
+    }
+}
+
+const logger = new Logger();
+function setVerbosity(verbosity: EVerbosity): void {
+    logger.verbosity = verbosity;
+}
+
+export { EVerbosity, logger, setVerbosity };

--- a/src/lib/helpers/logger.ts
+++ b/src/lib/helpers/logger.ts
@@ -1,42 +1,53 @@
-enum EVerbosity {
+enum ELogLevel {
     WARN = 0,
     INFO,
     DEBUG,
     DIAGNOSTIC,
 }
 
+type LevelStyle = {
+    readonly method: 'error' | 'warn' | 'log' | 'debug';
+    readonly colors: {
+        readonly header: string;
+        readonly message: string;
+    };
+};
+
 class Logger {
-    private static readonly prefix = 'aresrpg-engine: ';
-    public verbosity = EVerbosity.INFO;
+    // eslint-disable-next-line no-useless-constructor
+    public constructor(
+        private readonly prefix: string,
+        private readonly logStyle: Record<ELogLevel, LevelStyle>
+    ) { }
 
-    public warn(message: string): void {
-        if (this.verbosity >= EVerbosity.WARN) {
-            console.warn(Logger.prefix + message);
-        }
-    }
+    public verbosity = ELogLevel.INFO;
 
-    public info(message: string): void {
-        if (this.verbosity >= EVerbosity.INFO) {
-            console.info(Logger.prefix + message);
-        }
-    }
+    public readonly warn = this.log.bind(this, ELogLevel.WARN);
+    public readonly info = this.log.bind(this, ELogLevel.INFO);
+    public readonly debug = this.log.bind(this, ELogLevel.DEBUG);
+    public readonly diagnostic = this.log.bind(this, ELogLevel.DIAGNOSTIC);
 
-    public debug(message: string): void {
-        if (this.verbosity >= EVerbosity.DEBUG) {
-            console.debug(Logger.prefix + message);
-        }
-    }
+    private log(level: ELogLevel, message: string): void {
+        if (this.verbosity >= level) {
+            const logStyle = this.logStyle[level];
 
-    public diagnostic(message: string): void {
-        if (this.verbosity >= EVerbosity.DIAGNOSTIC) {
-            console.debug(Logger.prefix + message);
+            console[logStyle.method](
+                `%c${this.prefix}%c ${message}`,
+                `background: ${logStyle.colors.header}; color: white; padding: 2px 4px; border-radius: 2px`,
+                `font-weight: 800; color: ${logStyle.colors.message}`
+            );
         }
     }
 }
 
-const logger = new Logger();
-function setVerbosity(verbosity: EVerbosity): void {
+const logger = new Logger('aresrpg-engine', [
+    { method: 'warn', colors: { header: '#7B9E7B', message: '#FF6A00' } },
+    { method: 'log', colors: { header: '#7B9E7B', message: '#0094FF' } },
+    { method: 'debug', colors: { header: '#7B9E7B', message: '#808080' } },
+    { method: 'debug', colors: { header: '#7B9E7B', message: '#A56148' } },
+]);
+function setVerbosity(verbosity: ELogLevel): void {
     logger.verbosity = verbosity;
 }
 
-export { EVerbosity, logger, setVerbosity };
+export { ELogLevel, logger, setVerbosity };

--- a/src/lib/helpers/webgpu/webgpu-device.ts
+++ b/src/lib/helpers/webgpu/webgpu-device.ts
@@ -1,5 +1,7 @@
 /// <reference types="@webgpu/types" />
 
+import { logger } from '../logger';
+
 let devicePromise: Promise<GPUDevice> | null = null;
 
 async function getGpuDevice(): Promise<GPUDevice> {
@@ -18,7 +20,7 @@ async function getGpuDevice(): Promise<GPUDevice> {
         }
 
         if (adapter.isFallbackAdapter) {
-            console.warn('The retrieved GPU adapter is fallback. The performance might be degraded.');
+            logger.warn('The retrieved GPU adapter is fallback. The performance might be degraded.');
         }
 
         devicePromise = adapter.requestDevice();

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,2 +1,3 @@
+export { EVerbosity, setVerbosity } from './helpers/logger';
 export type { IVoxel, IVoxelMap, IVoxelMaterial } from './terrain/i-voxel-map';
 export { EPatchComputingMode, Terrain } from './terrain/terrain';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,3 @@
-export { EVerbosity, setVerbosity } from './helpers/logger';
+export { ELogLevel, setVerbosity } from './helpers/logger';
 export type { IVoxel, IVoxelMap, IVoxelMaterial } from './terrain/i-voxel-map';
 export { EPatchComputingMode, Terrain } from './terrain/terrain';

--- a/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
+++ b/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
@@ -100,8 +100,6 @@ abstract class PatchFactoryBase {
         boundingBox.getBoundingSphere(boundingSphere);
 
         return new Patch(
-            patchStart,
-            patchSize,
             geometryAndMaterialsList.map(geometryAndMaterial => {
                 const { geometry } = geometryAndMaterial;
                 geometry.boundingBox = boundingBox.clone();

--- a/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
+++ b/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
@@ -29,6 +29,7 @@ type FaceData = {
 type LocalMapCache = {
     readonly data: Uint16Array;
     readonly size: THREE.Vector3;
+    readonly isEmpty: boolean;
     neighbourExists(voxelIndex: number, neighbourRelativePosition: THREE.Vector3): boolean;
 };
 
@@ -206,6 +207,10 @@ abstract class PatchFactoryBase {
     }
 
     private *iterateOnVisibleFacesWithCache(localMapCache: LocalMapCache): Generator<FaceData> {
+        if (localMapCache.isEmpty) {
+            return;
+        }
+
         let cacheIndex = 0;
         const localPosition = new THREE.Vector3();
         for (localPosition.z = 0; localPosition.z < localMapCache.size.z; localPosition.z++) {
@@ -309,15 +314,18 @@ abstract class PatchFactoryBase {
             return neighbourData !== 0;
         };
 
+        let isEmpty = true;
         for (const voxel of this.map.iterateOnVoxels(cacheStart, cacheEnd)) {
             const localPosition = new THREE.Vector3().subVectors(voxel.position, cacheStart);
             const cacheIndex = buildIndex(localPosition);
             cache[cacheIndex] = 1 + voxel.materialId;
+            isEmpty = false;
         }
 
         return {
             data: cache,
             size: cacheSize,
+            isEmpty,
             neighbourExists,
         };
     }

--- a/src/lib/terrain/patch/patch-factory/split/gpu/patch-computer-gpu.ts
+++ b/src/lib/terrain/patch/patch-factory/split/gpu/patch-computer-gpu.ts
@@ -282,10 +282,13 @@ class PatchComputerGpu {
     }
 
     public dispose(): void {
+        this.localCacheBuffer.destroy();
         for (const buffer of Object.values(this.faceBuffers)) {
             buffer.storageBuffer.destroy();
             buffer.readableBuffer.destroy();
         }
+        logger.debug('Destroying WebGPU device...');
+        this.device.destroy();
     }
 }
 

--- a/src/lib/terrain/patch/patch-factory/split/gpu/patch-computer-gpu.ts
+++ b/src/lib/terrain/patch/patch-factory/split/gpu/patch-computer-gpu.ts
@@ -2,6 +2,7 @@
 
 import * as THREE from 'three';
 
+import { logger } from '../../../../../helpers/logger';
 import { getGpuDevice } from '../../../../../helpers/webgpu/webgpu-device';
 import * as Cube from '../../cube';
 import { type LocalMapCache } from '../../patch-factory-base';
@@ -16,6 +17,7 @@ type ComputationOutputs = Record<Cube.FaceType, Uint32Array>;
 
 class PatchComputerGpu {
     public static async create(localCacheSize: THREE.Vector3, vertexDataEncoder: VertexDataEncoder): Promise<PatchComputerGpu> {
+        logger.debug('Requesting WebGPU device...');
         const device = await getGpuDevice();
         return new PatchComputerGpu(device, localCacheSize, vertexDataEncoder);
     }
@@ -205,7 +207,7 @@ class PatchComputerGpu {
         Object.values(this.faceBuffers).forEach(
             faceBuffer => (totalBuffersSize += faceBuffer.readableBuffer.size + faceBuffer.storageBuffer.size)
         );
-        console.log(`Allocated ${(totalBuffersSize / 1024 / 1024).toFixed(1)} MB of webgpu buffers.`);
+        logger.info(`Allocated ${(totalBuffersSize / 1024 / 1024).toFixed(1)} MB of webgpu buffers.`);
 
         const bindgroupBuffers = [this.localCacheBuffer, ...Object.values(this.faceBuffers).map(faceBuffer => faceBuffer.storageBuffer)];
         this.computePipelineBindgroup = this.device.createBindGroup({

--- a/src/lib/terrain/patch/patch-factory/split/gpu/patch-factory-gpu-optimized.ts
+++ b/src/lib/terrain/patch/patch-factory/split/gpu/patch-factory-gpu-optimized.ts
@@ -30,14 +30,14 @@ class PatchFactoryGpuOptimized extends PatchFactoryGpu {
 
         return new Promise<GeometryAndMaterial[]>(resolve => {
             const patchId = this.nextPatchId++;
-            // console.log(`Asking for patch ${patchId}`);
+            // logger.diagnostic(`Asking for patch ${patchId}`);
 
             this.pendingJobs.push({
                 patchId,
                 cpuTask: () => {
-                    // console.log(`CPU ${patchId} start`);
+                    // logger.diagnostic(`CPU ${patchId} start`);
                     const result = this.buildLocalMapCache(patchStart, patchEnd);
-                    // console.log(`CPU ${patchId} end`);
+                    // logger.diagnostic(`CPU ${patchId} end`);
                     return result;
                 },
                 resolve,
@@ -59,10 +59,10 @@ class PatchFactoryGpuOptimized extends PatchFactoryGpu {
                 const localMapCache = currentJob.cpuTaskOutput;
 
                 currentJob.gpuTaskPromise = (async () => {
-                    // console.log(`GPU ${currentJob.patchId} start`);
+                    // logger.diagnostic(`GPU ${currentJob.patchId} start`);
                     const patchComputerGpu = await this.getPatchComputerGpu();
                     const gpuTaskOutput = await patchComputerGpu.computeBuffers(localMapCache);
-                    // console.log(`GPU ${currentJob.patchId} end`);
+                    // logger.diagnostic(`GPU ${currentJob.patchId} end`);
 
                     const result = this.assembleGeometryAndMaterials(gpuTaskOutput);
                     currentJob.resolve(result);

--- a/src/lib/terrain/patch/patch-factory/split/gpu/patch-factory-gpu-sequential.ts
+++ b/src/lib/terrain/patch/patch-factory/split/gpu/patch-factory-gpu-sequential.ts
@@ -21,6 +21,9 @@ class PatchFactoryGpuSequential extends PatchFactoryGpu {
             }
 
             const localMapCache = this.buildLocalMapCache(patchStart, patchEnd);
+            if (localMapCache.isEmpty) {
+                return [];
+            }
 
             const patchComputerGpu = await this.getPatchComputerGpu();
             const buffers = await patchComputerGpu.computeBuffers(localMapCache);

--- a/src/lib/terrain/patch/patch.ts
+++ b/src/lib/terrain/patch/patch.ts
@@ -31,16 +31,11 @@ class Patch {
         },
     };
 
-    public readonly patchStart: THREE.Vector3;
-    public readonly patchSize: THREE.Vector3;
-
     private gpuResources: {
         readonly patchMeshes: ReadonlyArray<PatchMesh>;
     } | null = null;
 
-    public constructor(patchStart: THREE.Vector3, patchSize: THREE.Vector3, patchMeshes: PatchMesh[]) {
-        this.patchStart = patchStart;
-        this.patchSize = patchSize;
+    public constructor(patchMeshes: PatchMesh[]) {
         this.gpuResources = { patchMeshes };
 
         this.container = new THREE.Object3D();

--- a/src/lib/terrain/terrain.ts
+++ b/src/lib/terrain/terrain.ts
@@ -105,8 +105,8 @@ class Terrain {
      * @param radius The visibility radius, in voxels.
      */
     public async showMapAroundPosition(position: THREE.Vector3, radius: number): Promise<void> {
-        const voxelFrom = new THREE.Vector3().copy(position).subScalar(radius);
-        const voxelTo = new THREE.Vector3().copy(position).addScalar(radius);
+        const voxelFrom = new THREE.Vector3().copy(position).subScalar(radius).max({ x: 0, y: 0, z: 0 });
+        const voxelTo = new THREE.Vector3().copy(position).addScalar(radius).min(this.map.size);
         const patchIdFrom = voxelFrom.divide(this.patchSize).floor();
         const patchIdTo = voxelTo.divide(this.patchSize).ceil();
 

--- a/src/lib/terrain/terrain.ts
+++ b/src/lib/terrain/terrain.ts
@@ -114,15 +114,20 @@ class Terrain {
             patch.visible = false;
         }
 
+        const visibilitySphere = new THREE.Sphere(position, radius);
         const promises: Promise<void>[] = [];
         const patchId = new THREE.Vector3();
         for (patchId.x = patchIdFrom.x; patchId.x < patchIdTo.x; patchId.x++) {
             for (patchId.y = patchIdFrom.y; patchId.y < patchIdTo.y; patchId.y++) {
                 for (patchId.z = patchIdFrom.z; patchId.z < patchIdTo.z; patchId.z++) {
                     const patchStart = new THREE.Vector3().multiplyVectors(patchId, this.patchSize);
-                    const patch = this.getPatch(patchStart);
-                    patch.visible = true;
-                    promises.push(patch.ready());
+
+                    const boundingBox = new THREE.Box3(patchStart, patchStart.clone().add(this.patchSize));
+                    if (visibilitySphere.intersectsBox(boundingBox)) {
+                        const patch = this.getPatch(patchStart);
+                        patch.visible = true;
+                        promises.push(patch.ready());
+                    }
                 }
             }
         }

--- a/src/lib/terrain/terrain.ts
+++ b/src/lib/terrain/terrain.ts
@@ -1,3 +1,4 @@
+import { logger } from '../helpers/logger';
 import * as THREE from '../three-usage';
 
 import { AsyncPatch } from './async-patch';
@@ -73,7 +74,7 @@ class Terrain {
         }
 
         this.patchSize = this.patchFactory.maxPatchSize.clone();
-        console.log(`Using max patch size ${this.patchSize.x}x${this.patchSize.y}x${this.patchSize.z}.`);
+        logger.info(`Using max patch size ${this.patchSize.x}x${this.patchSize.y}x${this.patchSize.z}.`);
 
         this.container = new THREE.Group();
     }

--- a/src/test/main.ts
+++ b/src/test/main.ts
@@ -39,7 +39,7 @@ camera.position.set(-50, 100, -50);
 const cameraControl = new OrbitControls(camera, renderer.domElement);
 cameraControl.target.set(voxelMap.size.x / 2, 0, voxelMap.size.z / 2);
 
-const playerViewRadius = 32;
+const playerViewRadius = 40;
 const playerContainer = new THREE.Group();
 playerContainer.position.x = voxelMap.size.x / 2;
 playerContainer.position.y = voxelMap.size.y + 1;

--- a/src/test/main.ts
+++ b/src/test/main.ts
@@ -1,9 +1,11 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
-import { Terrain } from '../lib/index';
+import { Terrain, setVerbosity, EVerbosity } from '../lib/index';
 
 import { VoxelMap } from './voxel-map';
+
+setVerbosity(EVerbosity.DIAGNOSTIC);
 
 const renderer = new THREE.WebGLRenderer();
 document.body.appendChild(renderer.domElement);

--- a/src/test/main.ts
+++ b/src/test/main.ts
@@ -1,12 +1,16 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { TransformControls } from 'three/examples/jsm/controls/TransformControls.js';
+import Stats from 'three/examples/jsm/libs/stats.module.js';
 
 import { EVerbosity, Terrain, setVerbosity } from '../lib/index';
 
 import { VoxelMap } from './voxel-map';
 
 setVerbosity(EVerbosity.DIAGNOSTIC);
+
+const stats = new Stats();
+document.body.appendChild(stats.dom);
 
 const renderer = new THREE.WebGLRenderer();
 document.body.appendChild(renderer.domElement);
@@ -60,6 +64,8 @@ setInterval(() => {
 
 // terrain.showEntireMap();
 function render(): void {
+    stats.update();
+
     cameraControl.update();
     terrain.updateUniforms();
     renderer.render(scene, camera);


### PR DESCRIPTION
This PR contains various fixes and optimizations of the way the GPU memory is handled:
- abort computation early for patches that contain no voxels
- `Terrain.showMapAroundPosition()` is now more strict now, and only shows patches that will be visible for sure
- `Terrain` now removes from GPU memory patches that have been invisible for a long time. As a reminder, a patch can become invisible if it was computed once and then went out of sight because the player moved. The size of this LRU cache is configurable with the new `Terrain.patchesCacheSize` attribute
- Added a proper logging module. Its verbosity can be controlled with the exposed `setVerbosity` method.