### PR TITLE
Feat: add support for advanced lighting and shadows

### DIFF
--- a/src/lib/terrain/patch/material.ts
+++ b/src/lib/terrain/patch/material.ts
@@ -31,4 +31,9 @@ type PatchMaterial = THREE.Material & {
     readonly uniforms: PatchMaterialUniforms;
 };
 
-export { EDisplayMode, EMaterial, type PatchMaterial, type PatchMaterialUniforms };
+type PatchMaterials = {
+    readonly material: PatchMaterial;
+    readonly shadowMaterial: THREE.Material;
+};
+
+export { EDisplayMode, EMaterial, type PatchMaterial, type PatchMaterials, type PatchMaterialUniforms };

--- a/src/lib/terrain/patch/material.ts
+++ b/src/lib/terrain/patch/material.ts
@@ -28,7 +28,9 @@ type PatchMaterialUniforms = {
 };
 
 type PatchMaterial = THREE.Material & {
-    readonly uniforms: PatchMaterialUniforms;
+    readonly userData: {
+        readonly uniforms: PatchMaterialUniforms;
+    };
 };
 
 type PatchMaterials = {

--- a/src/lib/terrain/patch/material.ts
+++ b/src/lib/terrain/patch/material.ts
@@ -20,8 +20,11 @@ type PatchMaterialUniforms = {
     readonly uAoSpread: { value: number };
     readonly uSmoothEdgeRadius: { value: number };
     readonly uSmoothEdgeMethod: { value: number };
-    readonly uAmbient: { value: number };
-    readonly uDiffuse: { value: number };
+
+    readonly uLightColor: { value: THREE.Color };
+    readonly uAmbientIntensity: { value: number };
+    readonly uDiffuseDirection: { value: THREE.Vector3 };
+    readonly uDiffuseIntensity: { value: number };
 };
 
 type PatchMaterial = THREE.Material & {

--- a/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
+++ b/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
@@ -74,10 +74,10 @@ abstract class PatchFactoryBase {
             uSmoothEdgeRadius: { value: 0 },
             uSmoothEdgeMethod: { value: 0 },
 
-            uLightColor: { value: new THREE.Color() },
-            uAmbientIntensity: { value: 0 },
-            uDiffuseDirection: { value: new THREE.Vector3() },
-            uDiffuseIntensity: { value: 0 },
+            uLightColor: { value: new THREE.Color(0xFFFFFF) },
+            uAmbientIntensity: { value: 0.7 },
+            uDiffuseDirection: { value: new THREE.Vector3(1, 1, 1).normalize() },
+            uDiffuseIntensity: { value: 0.8 },
         };
         this.uniformsTemplate.uTexture.value = this.texture;
     }

--- a/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
+++ b/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
@@ -74,7 +74,7 @@ abstract class PatchFactoryBase {
             uSmoothEdgeRadius: { value: 0 },
             uSmoothEdgeMethod: { value: 0 },
 
-            uLightColor: { value: new THREE.Color(0xFFFFFF) },
+            uLightColor: { value: new THREE.Color(0xffffff) },
             uAmbientIntensity: { value: 0.7 },
             uDiffuseDirection: { value: new THREE.Vector3(1, 1, 1).normalize() },
             uDiffuseIntensity: { value: 0.8 },

--- a/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
+++ b/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
@@ -113,6 +113,7 @@ abstract class PatchFactoryBase {
                 const mesh = new THREE.Mesh(geometryAndMaterial.geometry, material);
                 mesh.customDepthMaterial = shadowMaterial;
                 mesh.castShadow = true;
+                mesh.receiveShadow = true;
                 mesh.frustumCulled = false;
                 mesh.translateX(patchStart.x);
                 mesh.translateY(patchStart.y);

--- a/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
+++ b/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
@@ -108,8 +108,8 @@ abstract class PatchFactoryBase {
                 geometry.boundingBox = boundingBox.clone();
                 geometry.boundingSphere = boundingSphere.clone();
 
-                const material = geometryAndMaterial.materials.material.clone();
-                const shadowMaterial = geometryAndMaterial.materials.shadowMaterial.clone();
+                const material = geometryAndMaterial.materials.material;
+                const shadowMaterial = geometryAndMaterial.materials.shadowMaterial;
                 const mesh = new THREE.Mesh(geometryAndMaterial.geometry, material);
                 mesh.customDepthMaterial = shadowMaterial;
                 mesh.castShadow = true;

--- a/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
+++ b/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
@@ -73,8 +73,11 @@ abstract class PatchFactoryBase {
             uAoSpread: { value: 0 },
             uSmoothEdgeRadius: { value: 0 },
             uSmoothEdgeMethod: { value: 0 },
-            uAmbient: { value: 0 },
-            uDiffuse: { value: 0 },
+
+            uLightColor: { value: new THREE.Color() },
+            uAmbientIntensity: { value: 0 },
+            uDiffuseDirection: { value: new THREE.Vector3() },
+            uDiffuseIntensity: { value: 0 },
         };
         this.uniformsTemplate.uTexture.value = this.texture;
     }

--- a/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
+++ b/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
@@ -1,6 +1,6 @@
 import * as THREE from '../../../three-usage';
 import type { IVoxelMap, IVoxelMaterial } from '../../i-voxel-map';
-import type { PatchMaterial, PatchMaterialUniforms } from '../material';
+import type { PatchMaterials, PatchMaterialUniforms } from '../material';
 import { Patch } from '../patch';
 
 import * as Cube from './cube';
@@ -8,7 +8,7 @@ import type { PackedUintFragment } from './uint-packing';
 
 type GeometryAndMaterial = {
     readonly geometry: THREE.BufferGeometry;
-    readonly material: PatchMaterial;
+    readonly materials: PatchMaterials;
 };
 
 type VertexData = {
@@ -108,13 +108,21 @@ abstract class PatchFactoryBase {
                 geometry.boundingBox = boundingBox.clone();
                 geometry.boundingSphere = boundingSphere.clone();
 
-                const material = geometryAndMaterial.material.clone();
+                const material = geometryAndMaterial.materials.material.clone();
+                const shadowMaterial = geometryAndMaterial.materials.shadowMaterial.clone();
                 const mesh = new THREE.Mesh(geometryAndMaterial.geometry, material);
+                mesh.customDepthMaterial = shadowMaterial;
+                mesh.castShadow = true;
                 mesh.frustumCulled = false;
                 mesh.translateX(patchStart.x);
                 mesh.translateY(patchStart.y);
                 mesh.translateZ(patchStart.z);
-                return { mesh, material };
+
+                const materials = {
+                    material,
+                    shadowMaterial,
+                };
+                return { mesh, materials };
             })
         );
     }

--- a/src/lib/terrain/patch/patch-factory/split/patch-factory.ts
+++ b/src/lib/terrain/patch/patch-factory/split/patch-factory.ts
@@ -87,8 +87,10 @@ abstract class PatchFactory extends PatchFactoryBase {
         uniform sampler2D uTexture;
         uniform sampler2D uNoiseTexture;
         uniform float uNoiseStrength;
-        uniform float uAmbient;
-        uniform float uDiffuse;
+        uniform vec3 uLightColor;
+        uniform float uAmbientIntensity;
+        uniform vec3 uDiffuseDirection;
+        uniform float uDiffuseIntensity;
         uniform float uAoStrength;
         uniform float uAoSpread;
         uniform float uSmoothEdgeRadius;
@@ -158,13 +160,12 @@ abstract class PatchFactory extends PatchFactoryBase {
 
             color += computeNoise();
             
-            const vec3 diffuseDirection = normalize(vec3(1, 1, 1));
-            float diffuse = max(0.0, dot(modelFaceNormal, diffuseDirection));
+            float diffuse = max(0.0, dot(modelFaceNormal, uDiffuseDirection));
 
-            float light = uAmbient + uDiffuse * diffuse;
+            float lightIntensity = uAmbientIntensity + uDiffuseIntensity * diffuse;
             float ao = (1.0 - uAoStrength) + uAoStrength * (smoothstep(0.0, uAoSpread, 1.0 - vAo));
-            light *= ao;
-            color *= light;
+            lightIntensity *= ao;
+            color *= lightIntensity * uLightColor;
 
             fragColor = vec4(color, 1);
         }

--- a/src/lib/terrain/patch/patch-factory/split/patch-factory.ts
+++ b/src/lib/terrain/patch/patch-factory/split/patch-factory.ts
@@ -265,10 +265,6 @@ void main() {`,
 uniform sampler2D uTexture;
 uniform sampler2D uNoiseTexture;
 uniform float uNoiseStrength;
-uniform vec3 uLightColor;
-uniform float uAmbientIntensity;
-uniform vec3 uDiffuseDirection;
-uniform float uDiffuseIntensity;
 uniform float uAoStrength;
 uniform float uAoSpread;
 uniform float uSmoothEdgeRadius;

--- a/src/lib/terrain/patch/patch-factory/split/patch-factory.ts
+++ b/src/lib/terrain/patch/patch-factory/split/patch-factory.ts
@@ -43,7 +43,7 @@ abstract class PatchFactory extends PatchFactoryBase {
             const uint vertexIds[] = uint[](${Cube.faceIndices.map(indice => `${indice}u`).join(', ')});
             uint vertexId = vertexIds[gl_VertexID % 6];
 
-            uvec3 worldVoxelPosition = uvec3(
+            uvec3 modelVoxelPosition = uvec3(
                 ${PatchFactory.vertexDataEncoder.voxelX.glslDecode(PatchFactory.dataAttributeName)},
                 ${PatchFactory.vertexDataEncoder.voxelY.glslDecode(PatchFactory.dataAttributeName)},
                 ${PatchFactory.vertexDataEncoder.voxelZ.glslDecode(PatchFactory.dataAttributeName)}
@@ -55,8 +55,8 @@ abstract class PatchFactory extends PatchFactoryBase {
                     .join(',\n')}
             );
             uvec3 localVertexPosition = localVertexPositions[vertexId];
-            vec3 worldPosition = vec3(worldVoxelPosition + localVertexPosition);
-            gl_Position = projectionMatrix * modelViewMatrix * vec4(worldPosition, 1.0);
+            vec3 modelPosition = vec3(modelVoxelPosition + localVertexPosition);
+            gl_Position = projectionMatrix * modelViewMatrix * vec4(modelPosition, 1.0);
 
             const vec2 uvs[] = vec2[](
                 vec2(0,0),
@@ -80,7 +80,7 @@ abstract class PatchFactory extends PatchFactoryBase {
             )}) / ${PatchFactory.vertexDataEncoder.ao.maxValue.toFixed(1)};
 
             vMaterial = int(${PatchFactory.vertexDataEncoder.voxelMaterialId.glslDecode(PatchFactory.dataAttributeName)});
-            vNoise = int(worldVoxelPosition.x + worldVoxelPosition.y * 3u + worldVoxelPosition.z * 2u) % ${this.noiseTypes};
+            vNoise = int(modelVoxelPosition.x + modelVoxelPosition.y * 3u + modelVoxelPosition.z * 2u) % ${this.noiseTypes};
         }`,
             fragmentShader: `precision mediump float;
 
@@ -191,7 +191,7 @@ abstract class PatchFactory extends PatchFactoryBase {
             const uint vertexIds[] = uint[](${Cube.faceIndices.map(indice => `${indice}u`).join(', ')});
             uint vertexId = vertexIds[gl_VertexID % 6];
 
-            uvec3 worldVoxelPosition = uvec3(
+            uvec3 modelVoxelPosition = uvec3(
                 ${PatchFactory.vertexDataEncoder.voxelX.glslDecode(PatchFactory.dataAttributeName)},
                 ${PatchFactory.vertexDataEncoder.voxelY.glslDecode(PatchFactory.dataAttributeName)},
                 ${PatchFactory.vertexDataEncoder.voxelZ.glslDecode(PatchFactory.dataAttributeName)}
@@ -203,8 +203,8 @@ abstract class PatchFactory extends PatchFactoryBase {
                     .join(',\n')}
             );
             uvec3 localVertexPosition = localVertexPositions[vertexId];
-            vec3 worldPosition = vec3(worldVoxelPosition + localVertexPosition);
-            gl_Position = projectionMatrix * modelViewMatrix * vec4(worldPosition, 1.0);
+            vec3 modelPosition = vec3(modelVoxelPosition + localVertexPosition);
+            gl_Position = projectionMatrix * modelViewMatrix * vec4(modelPosition, 1.0);
 
             vHighPrecisionZW = gl_Position.zw;
         }`,

--- a/src/lib/terrain/patch/patch.ts
+++ b/src/lib/terrain/patch/patch.ts
@@ -15,16 +15,6 @@ class Patch {
             displayMode: EDisplayMode.TEXTURES,
             noiseStrength: 0.05,
         },
-        lighting: {
-            color: new THREE.Color(0xffffff),
-            ambient: {
-                intensity: 0.7,
-            },
-            diffuse: {
-                direction: new THREE.Vector3(1, 1, 1).normalize(),
-                intensity: 0.8,
-            },
-        },
         smoothEdges: {
             enabled: true,
             radius: 0.1,
@@ -61,11 +51,6 @@ class Patch {
                 uniforms.uSmoothEdgeRadius.value = +this.parameters.smoothEdges.enabled * this.parameters.smoothEdges.radius;
                 uniforms.uSmoothEdgeMethod.value = this.parameters.smoothEdges.quality;
                 uniforms.uDisplayMode.value = this.parameters.voxels.displayMode;
-
-                uniforms.uLightColor.value = this.parameters.lighting.color;
-                uniforms.uAmbientIntensity.value = this.parameters.lighting.ambient.intensity;
-                uniforms.uDiffuseDirection.value = this.parameters.lighting.diffuse.direction;
-                uniforms.uDiffuseIntensity.value = this.parameters.lighting.diffuse.intensity;
 
                 uniforms.uNoiseStrength.value = this.parameters.voxels.noiseStrength;
                 material.needsUpdate = true;

--- a/src/lib/terrain/patch/patch.ts
+++ b/src/lib/terrain/patch/patch.ts
@@ -1,10 +1,10 @@
 import * as THREE from '../../three-usage';
 
-import { EDisplayMode, PatchMaterial } from './material';
+import { EDisplayMode, PatchMaterials } from './material';
 
 type PatchMesh = {
     readonly mesh: THREE.Mesh;
-    readonly material: PatchMaterial;
+    readonly materials: PatchMaterials;
 };
 
 class Patch {
@@ -53,19 +53,20 @@ class Patch {
     public updateUniforms(): void {
         if (this.gpuResources) {
             for (const patchMesh of this.gpuResources.patchMeshes) {
-                patchMesh.material.uniforms.uAoStrength.value = +this.parameters.ao.enabled * this.parameters.ao.strength;
-                patchMesh.material.uniforms.uAoSpread.value = this.parameters.ao.spread;
-                patchMesh.material.uniforms.uSmoothEdgeRadius.value =
-                    +this.parameters.smoothEdges.enabled * this.parameters.smoothEdges.radius;
-                patchMesh.material.uniforms.uSmoothEdgeMethod.value = this.parameters.smoothEdges.quality;
-                patchMesh.material.uniforms.uDisplayMode.value = this.parameters.voxels.displayMode;
+                const material = patchMesh.materials.material;
 
-                patchMesh.material.uniforms.uLightColor.value = this.parameters.lighting.color;
-                patchMesh.material.uniforms.uAmbientIntensity.value = this.parameters.lighting.ambient.intensity;
-                patchMesh.material.uniforms.uDiffuseDirection.value = this.parameters.lighting.diffuse.direction;
-                patchMesh.material.uniforms.uDiffuseIntensity.value = this.parameters.lighting.diffuse.intensity;
+                material.uniforms.uAoStrength.value = +this.parameters.ao.enabled * this.parameters.ao.strength;
+                material.uniforms.uAoSpread.value = this.parameters.ao.spread;
+                material.uniforms.uSmoothEdgeRadius.value = +this.parameters.smoothEdges.enabled * this.parameters.smoothEdges.radius;
+                material.uniforms.uSmoothEdgeMethod.value = this.parameters.smoothEdges.quality;
+                material.uniforms.uDisplayMode.value = this.parameters.voxels.displayMode;
 
-                patchMesh.material.uniforms.uNoiseStrength.value = this.parameters.voxels.noiseStrength;
+                material.uniforms.uLightColor.value = this.parameters.lighting.color;
+                material.uniforms.uAmbientIntensity.value = this.parameters.lighting.ambient.intensity;
+                material.uniforms.uDiffuseDirection.value = this.parameters.lighting.diffuse.direction;
+                material.uniforms.uDiffuseIntensity.value = this.parameters.lighting.diffuse.intensity;
+
+                material.uniforms.uNoiseStrength.value = this.parameters.voxels.noiseStrength;
             }
         }
     }
@@ -75,7 +76,8 @@ class Patch {
             for (const patchMesh of this.gpuResources.patchMeshes) {
                 this.container.remove(patchMesh.mesh);
                 patchMesh.mesh.geometry.dispose();
-                patchMesh.material.dispose();
+                patchMesh.materials.material.dispose();
+                patchMesh.materials.shadowMaterial.dispose();
             }
 
             this.gpuResources = null;

--- a/src/lib/terrain/patch/patch.ts
+++ b/src/lib/terrain/patch/patch.ts
@@ -11,6 +11,10 @@ class Patch {
     public readonly container: THREE.Object3D;
 
     public readonly parameters = {
+        shadows: {
+            cast: true,
+            receive: true,
+        },
         voxels: {
             displayMode: EDisplayMode.TEXTURES,
             noiseStrength: 0.05,
@@ -54,6 +58,9 @@ class Patch {
 
                 uniforms.uNoiseStrength.value = this.parameters.voxels.noiseStrength;
                 material.needsUpdate = true;
+
+                patchMesh.mesh.receiveShadow = this.parameters.shadows.receive;
+                patchMesh.mesh.castShadow = this.parameters.shadows.cast;
             }
         }
     }

--- a/src/lib/terrain/patch/patch.ts
+++ b/src/lib/terrain/patch/patch.ts
@@ -54,19 +54,21 @@ class Patch {
         if (this.gpuResources) {
             for (const patchMesh of this.gpuResources.patchMeshes) {
                 const material = patchMesh.materials.material;
+                const uniforms = material.userData.uniforms;
 
-                material.uniforms.uAoStrength.value = +this.parameters.ao.enabled * this.parameters.ao.strength;
-                material.uniforms.uAoSpread.value = this.parameters.ao.spread;
-                material.uniforms.uSmoothEdgeRadius.value = +this.parameters.smoothEdges.enabled * this.parameters.smoothEdges.radius;
-                material.uniforms.uSmoothEdgeMethod.value = this.parameters.smoothEdges.quality;
-                material.uniforms.uDisplayMode.value = this.parameters.voxels.displayMode;
+                uniforms.uAoStrength.value = +this.parameters.ao.enabled * this.parameters.ao.strength;
+                uniforms.uAoSpread.value = this.parameters.ao.spread;
+                uniforms.uSmoothEdgeRadius.value = +this.parameters.smoothEdges.enabled * this.parameters.smoothEdges.radius;
+                uniforms.uSmoothEdgeMethod.value = this.parameters.smoothEdges.quality;
+                uniforms.uDisplayMode.value = this.parameters.voxels.displayMode;
 
-                material.uniforms.uLightColor.value = this.parameters.lighting.color;
-                material.uniforms.uAmbientIntensity.value = this.parameters.lighting.ambient.intensity;
-                material.uniforms.uDiffuseDirection.value = this.parameters.lighting.diffuse.direction;
-                material.uniforms.uDiffuseIntensity.value = this.parameters.lighting.diffuse.intensity;
+                uniforms.uLightColor.value = this.parameters.lighting.color;
+                uniforms.uAmbientIntensity.value = this.parameters.lighting.ambient.intensity;
+                uniforms.uDiffuseDirection.value = this.parameters.lighting.diffuse.direction;
+                uniforms.uDiffuseIntensity.value = this.parameters.lighting.diffuse.intensity;
 
-                material.uniforms.uNoiseStrength.value = this.parameters.voxels.noiseStrength;
+                uniforms.uNoiseStrength.value = this.parameters.voxels.noiseStrength;
+                material.needsUpdate = true;
             }
         }
     }

--- a/src/lib/terrain/patch/patch.ts
+++ b/src/lib/terrain/patch/patch.ts
@@ -16,8 +16,14 @@ class Patch {
             noiseStrength: 0.05,
         },
         lighting: {
-            ambient: 0.7,
-            diffuse: 0.8,
+            color: new THREE.Color(0xffffff),
+            ambient: {
+                intensity: 0.7,
+            },
+            diffuse: {
+                direction: new THREE.Vector3(1, 1, 1).normalize(),
+                intensity: 0.8,
+            },
         },
         smoothEdges: {
             enabled: true,
@@ -53,8 +59,12 @@ class Patch {
                     +this.parameters.smoothEdges.enabled * this.parameters.smoothEdges.radius;
                 patchMesh.material.uniforms.uSmoothEdgeMethod.value = this.parameters.smoothEdges.quality;
                 patchMesh.material.uniforms.uDisplayMode.value = this.parameters.voxels.displayMode;
-                patchMesh.material.uniforms.uAmbient.value = this.parameters.lighting.ambient;
-                patchMesh.material.uniforms.uDiffuse.value = this.parameters.lighting.diffuse;
+
+                patchMesh.material.uniforms.uLightColor.value = this.parameters.lighting.color;
+                patchMesh.material.uniforms.uAmbientIntensity.value = this.parameters.lighting.ambient.intensity;
+                patchMesh.material.uniforms.uDiffuseDirection.value = this.parameters.lighting.diffuse.direction;
+                patchMesh.material.uniforms.uDiffuseIntensity.value = this.parameters.lighting.diffuse.intensity;
+
                 patchMesh.material.uniforms.uNoiseStrength.value = this.parameters.voxels.noiseStrength;
             }
         }

--- a/src/lib/terrain/terrain.ts
+++ b/src/lib/terrain/terrain.ts
@@ -27,17 +27,6 @@ class Terrain {
             displayMode: EDisplayMode.TEXTURES,
             noiseStrength: 0.025,
         },
-        lighting: {
-            color: new THREE.Color(0xffffff),
-
-            ambient: {
-                intensity: 0.7,
-            },
-            diffuse: {
-                direction: new THREE.Vector3(1, 1, 1).normalize(),
-                intensity: 0.8,
-            },
-        },
         smoothEdges: {
             enabled: true,
             radius: 0.1,
@@ -150,15 +139,11 @@ class Terrain {
      * Call this method before rendering.
      * */
     public updateUniforms(): void {
-        this.parameters.lighting.diffuse.direction.normalize();
-
         for (const asyncPatch of Object.values(this.patches)) {
             const patch = asyncPatch.patch;
             if (patch) {
                 patch.parameters.voxels.displayMode = this.parameters.voxels.displayMode;
                 patch.parameters.voxels.noiseStrength = this.parameters.voxels.noiseStrength;
-
-                patch.parameters.lighting = this.parameters.lighting;
 
                 patch.parameters.smoothEdges.enabled = this.parameters.smoothEdges.enabled;
                 patch.parameters.smoothEdges.radius = this.parameters.smoothEdges.radius;

--- a/src/lib/terrain/terrain.ts
+++ b/src/lib/terrain/terrain.ts
@@ -28,7 +28,7 @@ class Terrain {
             noiseStrength: 0.025,
         },
         lighting: {
-            color: new THREE.Color(0xff9999),
+            color: new THREE.Color(0xffffff),
 
             ambient: {
                 intensity: 0.7,

--- a/src/lib/terrain/terrain.ts
+++ b/src/lib/terrain/terrain.ts
@@ -28,8 +28,15 @@ class Terrain {
             noiseStrength: 0.025,
         },
         lighting: {
-            ambient: 0.7,
-            diffuse: 0.8,
+            color: new THREE.Color(0xff9999),
+
+            ambient: {
+                intensity: 0.7,
+            },
+            diffuse: {
+                direction: new THREE.Vector3(1, 1, 1).normalize(),
+                intensity: 0.8,
+            },
         },
         smoothEdges: {
             enabled: true,
@@ -143,14 +150,15 @@ class Terrain {
      * Call this method before rendering.
      * */
     public updateUniforms(): void {
+        this.parameters.lighting.diffuse.direction.normalize();
+
         for (const asyncPatch of Object.values(this.patches)) {
             const patch = asyncPatch.patch;
             if (patch) {
                 patch.parameters.voxels.displayMode = this.parameters.voxels.displayMode;
                 patch.parameters.voxels.noiseStrength = this.parameters.voxels.noiseStrength;
 
-                patch.parameters.lighting.ambient = this.parameters.lighting.ambient;
-                patch.parameters.lighting.diffuse = this.parameters.lighting.diffuse;
+                patch.parameters.lighting = this.parameters.lighting;
 
                 patch.parameters.smoothEdges.enabled = this.parameters.smoothEdges.enabled;
                 patch.parameters.smoothEdges.radius = this.parameters.smoothEdges.radius;

--- a/src/lib/terrain/terrain.ts
+++ b/src/lib/terrain/terrain.ts
@@ -23,6 +23,10 @@ class Terrain {
     public readonly container: THREE.Object3D;
 
     public readonly parameters = {
+        shadows: {
+            cast: true,
+            receive: true,
+        },
         voxels: {
             displayMode: EDisplayMode.TEXTURES,
             noiseStrength: 0.025,
@@ -152,6 +156,9 @@ class Terrain {
                 patch.parameters.ao.enabled = this.parameters.ao.enabled;
                 patch.parameters.ao.strength = this.parameters.ao.strength;
                 patch.parameters.ao.spread = this.parameters.ao.spread;
+
+                patch.parameters.shadows = this.parameters.shadows;
+
                 patch.updateUniforms();
             }
         }

--- a/src/lib/three-usage.ts
+++ b/src/lib/three-usage.ts
@@ -5,6 +5,7 @@ export {
     DataTexture,
     Group,
     Mesh,
+    MeshPhongMaterial,
     Object3D,
     ShaderMaterial,
     Sphere,

--- a/src/lib/three-usage.ts
+++ b/src/lib/three-usage.ts
@@ -1,6 +1,7 @@
 export {
     Box3,
     BufferGeometry,
+    Color,
     DataTexture,
     Group,
     Mesh,

--- a/src/test/main.ts
+++ b/src/test/main.ts
@@ -110,11 +110,12 @@ if (testShadows) {
 
 scene.add(ambientLight);
 
-ambientLight.color = terrain.parameters.lighting.color;
-ambientLight.intensity = 0.3;
+const lightColor = new THREE.Color(0xFFFFFF);
+ambientLight.color = lightColor;
+ambientLight.intensity = 1;
 
-dirLight.color = terrain.parameters.lighting.color;
-dirLight.intensity = 1.5;
+dirLight.color = lightColor;
+dirLight.intensity = 3;
 
 function render(): void {
     stats.update();

--- a/src/test/main.ts
+++ b/src/test/main.ts
@@ -110,7 +110,7 @@ if (testShadows) {
 
 scene.add(ambientLight);
 
-const lightColor = new THREE.Color(0xFFFFFF);
+const lightColor = new THREE.Color(0xffffff);
 ambientLight.color = lightColor;
 ambientLight.intensity = 1;
 

--- a/src/test/main.ts
+++ b/src/test/main.ts
@@ -35,7 +35,7 @@ scene.add(terrain.container);
 
 scene.add(new THREE.AxesHelper(500));
 
-camera.position.set(-50, 100, -50);
+camera.position.set(-50, 100, 50);
 const cameraControl = new OrbitControls(camera, renderer.domElement);
 cameraControl.target.set(voxelMap.size.x / 2, 0, voxelMap.size.z / 2);
 
@@ -48,7 +48,7 @@ const player = new THREE.Mesh(new THREE.SphereGeometry(2), new THREE.MeshBasicMa
 playerContainer.add(player);
 scene.add(playerContainer);
 
-const showWholeMap = false;
+const showWholeMap = true;
 if (showWholeMap) {
     terrain.showEntireMap();
 } else {
@@ -68,6 +68,9 @@ if (showWholeMap) {
         terrain.showMapAroundPosition(playerContainer.position, playerViewRadius);
     }, 200);
 }
+
+const dirLight = new THREE.DirectionalLight(0xffffff, 1);
+const ambientLight = new THREE.AmbientLight(0xffffff);
 
 const testShadows = true;
 if (testShadows) {
@@ -89,22 +92,29 @@ if (testShadows) {
     // sphereCastingShadows.castShadow = true;
     // scene.add(sphereCastingShadows);
 
-    const dirLight = new THREE.DirectionalLight(0xffffff, 1);
     dirLight.target.position.set(0, 0, 0);
-    dirLight.position.set(100, 100, 100);
+    dirLight.position.set(100, 50, 100);
     dirLight.castShadow = true;
     dirLight.shadow.camera.top = 200;
     dirLight.shadow.camera.bottom = -200;
     dirLight.shadow.camera.left = -200;
     dirLight.shadow.camera.right = 200;
 
-    dirLight.shadow.mapSize.width = 512;
-    dirLight.shadow.mapSize.height = 512;
+    dirLight.shadow.mapSize.width = 1024;
+    dirLight.shadow.mapSize.height = 1024;
     scene.add(dirLight);
 
     renderer.shadowMap.enabled = true;
     renderer.shadowMap.type = THREE.PCFShadowMap;
 }
+
+scene.add(ambientLight);
+
+ambientLight.color = terrain.parameters.lighting.color;
+ambientLight.intensity = 0.3;
+
+dirLight.color = terrain.parameters.lighting.color;
+dirLight.intensity = 1.5;
 
 function render(): void {
     stats.update();

--- a/src/test/main.ts
+++ b/src/test/main.ts
@@ -45,27 +45,32 @@ playerContainer.position.x = voxelMap.size.x / 2;
 playerContainer.position.y = voxelMap.size.y + 1;
 playerContainer.position.z = voxelMap.size.z / 2;
 const player = new THREE.Mesh(new THREE.SphereGeometry(2), new THREE.MeshBasicMaterial({ color: '#FF0000' }));
-const playerViewSphere = new THREE.Mesh(
-    new THREE.SphereGeometry(playerViewRadius, 16, 16),
-    new THREE.MeshBasicMaterial({ color: 0xffffff, wireframe: true })
-);
 playerContainer.add(player);
-playerContainer.add(playerViewSphere);
-const playerControls = new TransformControls(camera, renderer.domElement);
-playerControls.addEventListener('dragging-changed', event => {
-    cameraControl.enabled = !event.value;
-});
-playerControls.attach(playerContainer);
 scene.add(playerContainer);
-scene.add(playerControls);
-// setInterval(() => {
-//     terrain.showMapAroundPosition(playerContainer.position, playerViewRadius);
-// }, 200);
-// terrain.parameters.lighting.diffuse.direction = new THREE.Vector3(-1, -1, -1);
-terrain.showEntireMap();
 
-// shadows testing
-{
+const showWholeMap = false;
+if (showWholeMap) {
+    terrain.showEntireMap();
+} else {
+    const playerViewSphere = new THREE.Mesh(
+        new THREE.SphereGeometry(playerViewRadius, 16, 16),
+        new THREE.MeshBasicMaterial({ color: 0xffffff, wireframe: true })
+    );
+    playerContainer.add(playerViewSphere);
+    const playerControls = new TransformControls(camera, renderer.domElement);
+    playerControls.addEventListener('dragging-changed', event => {
+        cameraControl.enabled = !event.value;
+    });
+    playerControls.attach(playerContainer);
+    scene.add(playerControls);
+
+    setInterval(() => {
+        terrain.showMapAroundPosition(playerContainer.position, playerViewRadius);
+    }, 200);
+}
+
+const testShadows = true;
+if (testShadows) {
     const planeReceivingShadows = new THREE.Mesh(new THREE.PlaneGeometry(200, 200), new THREE.MeshPhongMaterial());
     planeReceivingShadows.position.set(0, -20, 0);
     planeReceivingShadows.rotateOnAxis(new THREE.Vector3(1, 0, 0), -Math.PI / 4);
@@ -86,12 +91,12 @@ terrain.showEntireMap();
 
     const dirLight = new THREE.DirectionalLight(0xffffff, 1);
     dirLight.target.position.set(0, 0, 0);
-    dirLight.position.set(50, 50, 50);
+    dirLight.position.set(100, 100, 100);
     dirLight.castShadow = true;
-    dirLight.shadow.camera.top = 100;
-    dirLight.shadow.camera.bottom = -100;
-    dirLight.shadow.camera.left = -100;
-    dirLight.shadow.camera.right = 100;
+    dirLight.shadow.camera.top = 200;
+    dirLight.shadow.camera.bottom = -200;
+    dirLight.shadow.camera.left = -200;
+    dirLight.shadow.camera.right = 200;
 
     dirLight.shadow.mapSize.width = 512;
     dirLight.shadow.mapSize.height = 512;

--- a/src/test/main.ts
+++ b/src/test/main.ts
@@ -3,11 +3,11 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { TransformControls } from 'three/examples/jsm/controls/TransformControls.js';
 import Stats from 'three/examples/jsm/libs/stats.module.js';
 
-import { EVerbosity, Terrain, setVerbosity } from '../lib/index';
+import { ELogLevel, Terrain, setVerbosity } from '../lib/index';
 
 import { VoxelMap } from './voxel-map';
 
-setVerbosity(EVerbosity.DIAGNOSTIC);
+setVerbosity(ELogLevel.DIAGNOSTIC);
 
 const stats = new Stats();
 document.body.appendChild(stats.dom);
@@ -58,11 +58,49 @@ playerControls.addEventListener('dragging-changed', event => {
 playerControls.attach(playerContainer);
 scene.add(playerContainer);
 scene.add(playerControls);
-setInterval(() => {
-    terrain.showMapAroundPosition(playerContainer.position, playerViewRadius);
-}, 200);
+// setInterval(() => {
+//     terrain.showMapAroundPosition(playerContainer.position, playerViewRadius);
+// }, 200);
+// terrain.parameters.lighting.diffuse.direction = new THREE.Vector3(-1, -1, -1);
+terrain.showEntireMap();
 
-// terrain.showEntireMap();
+// shadows testing
+{
+    const planeReceivingShadows = new THREE.Mesh(new THREE.PlaneGeometry(200, 200), new THREE.MeshPhongMaterial());
+    planeReceivingShadows.position.set(0, -20, 0);
+    planeReceivingShadows.rotateOnAxis(new THREE.Vector3(1, 0, 0), -Math.PI / 4);
+    planeReceivingShadows.rotateOnAxis(new THREE.Vector3(0, 1, 0), Math.PI / 4);
+    planeReceivingShadows.receiveShadow = true;
+    scene.add(planeReceivingShadows);
+    const planeControls = new TransformControls(camera, renderer.domElement);
+    planeControls.addEventListener('dragging-changed', event => {
+        cameraControl.enabled = !event.value;
+    });
+    planeControls.attach(planeReceivingShadows);
+    scene.add(planeControls);
+
+    // const sphereCastingShadows = new THREE.Mesh(new THREE.SphereGeometry(10), new THREE.MeshPhongMaterial());
+    // sphereCastingShadows.position.set(20, 30, 20);
+    // sphereCastingShadows.castShadow = true;
+    // scene.add(sphereCastingShadows);
+
+    const dirLight = new THREE.DirectionalLight(0xffffff, 1);
+    dirLight.target.position.set(0, 0, 0);
+    dirLight.position.set(50, 50, 50);
+    dirLight.castShadow = true;
+    dirLight.shadow.camera.top = 100;
+    dirLight.shadow.camera.bottom = -100;
+    dirLight.shadow.camera.left = -100;
+    dirLight.shadow.camera.right = 100;
+
+    dirLight.shadow.mapSize.width = 512;
+    dirLight.shadow.mapSize.height = 512;
+    scene.add(dirLight);
+
+    renderer.shadowMap.enabled = true;
+    renderer.shadowMap.type = THREE.PCFShadowMap;
+}
+
 function render(): void {
     stats.update();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,7 @@
     "declaration": true,
     "declarationMap": false,
     "outDir": "dist",
-    "sourceMap": false,
+    "sourceMap": true,
 
     /* JavaScript Support */
     "allowJs": false,


### PR DESCRIPTION
This PR:
- adds support for cast shadows (casting, receiving and self-shadowing)
- gives the Terrain a modified `MeshPhongShader`, which means that the Terrain now behaves as any other mesh in the scene: it reacts to scene lights, has support for specularity etc.
- ships the sourcemaps in the npm package, which might help debugging

Here is an illustration of the terrain casting and receiving shadows:
![image](https://github.com/aresrpg/aresrpg-engine/assets/22922087/759b937e-b000-48b4-990b-1d0885423a02)
