### PR TITLE
Feat/externalize mapcache building

### DIFF
--- a/src/lib/helpers/async-task.ts
+++ b/src/lib/helpers/async-task.ts
@@ -1,0 +1,66 @@
+type PromiseCreator<T> = () => Promise<T>;
+
+class AsyncTask<T> {
+    private readonly starter: PromiseCreator<T>;
+
+    private run:
+        | null
+        | {
+              state: 'STARTED';
+              promise: Promise<T>;
+          }
+        | {
+              state: 'FINISHED';
+              result: T;
+          } = null;
+
+    public constructor(starter: PromiseCreator<T>) {
+        this.starter = starter;
+    }
+
+    public start(): void {
+        if (this.run) {
+            throw new Error('Task is already started.');
+        }
+
+        this.run = {
+            state: 'STARTED',
+            promise: this.starter(),
+        };
+        this.run.promise.then(result => {
+            if (this.run?.state !== 'STARTED') {
+                throw new Error('Task is in invalid state');
+            }
+            this.run = {
+                state: 'FINISHED',
+                result,
+            };
+        });
+    }
+
+    public get isStarted(): boolean {
+        return !!this.run;
+    }
+
+    public get isFinished(): boolean {
+        return this.run?.state === 'FINISHED';
+    }
+
+    public getResultSync(): T {
+        if (this.run?.state !== 'FINISHED') {
+            throw new Error('Task is not finished.');
+        }
+        return this.run.result;
+    }
+
+    public async awaitResult(): Promise<T> {
+        if (!this.run) {
+            throw new Error('Task is not started.');
+        } else if (this.run.state === 'STARTED') {
+            return await this.run.promise;
+        }
+        return this.run.result;
+    }
+}
+
+export { AsyncTask };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,3 @@
 export { ELogLevel, setVerbosity } from './helpers/logger';
-export type { IVoxel, IVoxelMap, IVoxelMaterial } from './terrain/i-voxel-map';
+export type { IVoxelMap, IVoxelMaterial, ILocalMapData } from './terrain/i-voxel-map';
 export { EPatchComputingMode, Terrain } from './terrain/terrain';

--- a/src/lib/terrain/i-voxel-map.ts
+++ b/src/lib/terrain/i-voxel-map.ts
@@ -1,8 +1,4 @@
-type Uint3 = {
-    readonly x: number;
-    readonly y: number;
-    readonly z: number;
-};
+import type { Vector3Like } from '../three-usage';
 
 /**
  * A color stored in RGB format. Each component should be normalized.
@@ -17,18 +13,14 @@ interface IVoxelMaterial {
     readonly color: Color;
 }
 
-/**
- * A representation of a voxel.
- */
-interface IVoxel {
-    readonly position: Uint3;
-    readonly materialId: number;
+interface ILocalMapData {
+    readonly data: Uint16Array;
+    readonly isEmpty: boolean;
 }
 
 /**
  * Interface for a class storing a 3D voxel map.
- * Each voxel should have positive integer coordinates.
- * The map starts at coordinates { x: 0, y: 0, z: 0 }.
+ * Each voxel should have integer coordinates.
  */
 interface IVoxelMap {
     /**
@@ -37,17 +29,7 @@ interface IVoxelMap {
      */
     readonly voxelMaterialsList: ReadonlyArray<IVoxelMaterial>;
 
-    /**
-     * Iterates on all for voxels within a given sub-section of the map.
-     * @param from Start of the subsection
-     * @param to End of the subsection (exclusive)
-     */
-    iterateOnVoxels(from: Uint3, to: Uint3): Generator<IVoxel>;
-
-    /**
-     * @returns whether or not a voxel exists at these coordinates.
-     */
-    voxelExists(x: number, y: number, z: number): boolean;
+    getLocalMapData(from: Vector3Like, to: Vector3Like): Promise<ILocalMapData>;
 }
 
-export type { IVoxel, IVoxelMap, IVoxelMaterial };
+export type { IVoxelMap, IVoxelMaterial, ILocalMapData };

--- a/src/lib/terrain/i-voxel-map.ts
+++ b/src/lib/terrain/i-voxel-map.ts
@@ -38,13 +38,6 @@ interface IVoxelMap {
     readonly voxelMaterialsList: ReadonlyArray<IVoxelMaterial>;
 
     /**
-     * @param from Start of the subsection
-     * @param to End of the subsection (exclusive)
-     * @returns An upper bound of the count of voxels withing the given sub-section of the map.
-     */
-    getMaxVoxelsCount(from: Uint3, to: Uint3): number;
-
-    /**
      * Iterates on all for voxels within a given sub-section of the map.
      * @param from Start of the subsection
      * @param to End of the subsection (exclusive)

--- a/src/lib/terrain/i-voxel-map.ts
+++ b/src/lib/terrain/i-voxel-map.ts
@@ -20,10 +20,10 @@ interface ILocalMapData {
      * An element:
      * - should be equal to 0 if there is no voxel at these coordinates
      * - should be equal to the voxel's material id + 1 if there is a voxel at these coordinates
-     * 
+     *
      * The elements should be ordered by coordinates as follow by Z first, then Y then X.
      * For example, for a portion of the map between (0,0,0) and (2,2,2): (0,0,0) then (1,0,0) then (0,1,0) then (1,1,0) then (0,1,1) then (1,1,1)
-    */
+     */
     readonly data: Uint16Array;
 
     /** Should be:

--- a/src/lib/terrain/i-voxel-map.ts
+++ b/src/lib/terrain/i-voxel-map.ts
@@ -13,8 +13,23 @@ interface IVoxelMaterial {
     readonly color: Color;
 }
 
+/** Compact object storing a portion of the map data  */
 interface ILocalMapData {
+    /** Compact array storing the voxel data.
+     * Each element in the array represent a coordinate in the map and stores the data of the voxel at these coordinates.
+     * An element:
+     * - should be equal to 0 if there is no voxel at these coordinates
+     * - should be equal to the voxel's material id + 1 if there is a voxel at these coordinates
+     * 
+     * The elements should be ordered by coordinates as follow by Z first, then Y then X.
+     * For example, for a portion of the map between (0,0,0) and (2,2,2): (0,0,0) then (1,0,0) then (0,1,0) then (1,1,0) then (0,1,1) then (1,1,1)
+    */
     readonly data: Uint16Array;
+
+    /** Should be:
+     * - true if there are no voxels in the data
+     * - false if there is at least one voxel in the data
+     */
     readonly isEmpty: boolean;
 }
 
@@ -29,6 +44,11 @@ interface IVoxelMap {
      */
     readonly voxelMaterialsList: ReadonlyArray<IVoxelMaterial>;
 
+    /**
+     * @returns an object storing the voxels data for the specified portion of the map.
+     * @param from Lower limit (inclusive) for the voxels coordinates
+     * @param to Upper limit (exclusive) for the voxels coordinates
+     */
     getLocalMapData(from: Vector3Like, to: Vector3Like): Promise<ILocalMapData>;
 }
 

--- a/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
+++ b/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
@@ -234,7 +234,7 @@ abstract class PatchFactoryBase {
     protected abstract disposeInternal(): void;
 
     protected async buildLocalMapCache(patchStart: THREE.Vector3, patchEnd: THREE.Vector3): Promise<LocalMapCache> {
-        const localMapData = await this.buildLocalMapData(patchStart, patchEnd);
+        const localMapData = await this.map.getLocalMapData(patchStart, patchEnd);
 
         const cacheStart = patchStart.clone().subScalar(1);
         const cacheEnd = patchEnd.clone().addScalar(1);
@@ -265,35 +265,6 @@ abstract class PatchFactoryBase {
             size: cacheSize,
             neighbourExists,
         });
-    }
-
-    private async buildLocalMapData(patchStart: THREE.Vector3, patchEnd: THREE.Vector3): Promise<LocalMapData> {
-        const cacheStart = patchStart.clone().subScalar(1);
-        const cacheEnd = patchEnd.clone().addScalar(1);
-        const cacheSize = new THREE.Vector3().subVectors(cacheEnd, cacheStart);
-        const cache = new Uint16Array(cacheSize.x * cacheSize.y * cacheSize.z);
-
-        const indexFactor = { x: 1, y: cacheSize.x, z: cacheSize.x * cacheSize.y };
-
-        const buildIndex = (position: THREE.Vector3) => {
-            if (position.x < 0 || position.y < 0 || position.z < 0) {
-                throw new Error();
-            }
-            return position.x * indexFactor.x + position.y * indexFactor.y + position.z * indexFactor.z;
-        };
-
-        let isEmpty = true;
-        for (const voxel of this.map.iterateOnVoxels(cacheStart, cacheEnd)) {
-            const localPosition = new THREE.Vector3().subVectors(voxel.position, cacheStart);
-            const cacheIndex = buildIndex(localPosition);
-            cache[cacheIndex] = 1 + voxel.materialId;
-            isEmpty = false;
-        }
-
-        return {
-            data: cache,
-            isEmpty,
-        };
     }
 
     private static buildMaterialsTexture(

--- a/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
+++ b/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
@@ -234,11 +234,11 @@ abstract class PatchFactoryBase {
     protected abstract disposeInternal(): void;
 
     protected async buildLocalMapCache(patchStart: THREE.Vector3, patchEnd: THREE.Vector3): Promise<LocalMapCache> {
-        const localMapData = await this.map.getLocalMapData(patchStart, patchEnd);
-
         const cacheStart = patchStart.clone().subScalar(1);
         const cacheEnd = patchEnd.clone().addScalar(1);
         const cacheSize = new THREE.Vector3().subVectors(cacheEnd, cacheStart);
+
+        const localMapData = await this.map.getLocalMapData(cacheStart, cacheEnd);
 
         const expectedCacheItemsCount = cacheSize.x * cacheSize.y * cacheSize.z;
         if (localMapData.data.length !== expectedCacheItemsCount) {

--- a/src/lib/terrain/patch/patch-factory/split/cpu/patch-factory-cpu.ts
+++ b/src/lib/terrain/patch/patch-factory/split/cpu/patch-factory-cpu.ts
@@ -5,7 +5,7 @@ import { type IVoxelMap } from '../../../../i-voxel-map';
 
 class PatchFactoryCpu extends PatchFactory {
     public constructor(map: IVoxelMap, computingMode: EPatchComputingMode) {
-        if (computingMode !== EPatchComputingMode.CPU_CACHED && computingMode !== EPatchComputingMode.CPU_SIMPLE) {
+        if (computingMode !== EPatchComputingMode.CPU_CACHED) {
             throw new Error();
         }
         super(map, computingMode);

--- a/src/lib/terrain/patch/patch-factory/split/cpu/patch-factory-cpu.ts
+++ b/src/lib/terrain/patch/patch-factory/split/cpu/patch-factory-cpu.ts
@@ -1,7 +1,7 @@
 import { EPatchComputingMode, type GeometryAndMaterial, type VertexData } from '../../patch-factory-base';
 import { PatchFactory } from '../patch-factory';
 import * as Cube from '../../cube';
-import { IVoxelMap } from '../../../../i-voxel-map';
+import { type IVoxelMap } from '../../../../i-voxel-map';
 
 class PatchFactoryCpu extends PatchFactory {
     public constructor(map: IVoxelMap, computingMode: EPatchComputingMode) {

--- a/src/lib/terrain/patch/patch-factory/split/cpu/patch-factory-cpu.ts
+++ b/src/lib/terrain/patch/patch-factory/split/cpu/patch-factory-cpu.ts
@@ -9,6 +9,8 @@ class PatchFactoryCpu extends PatchFactory {
     }
 
     protected async computePatchData(patchStart: THREE.Vector3, patchEnd: THREE.Vector3): Promise<GeometryAndMaterial[]> {
+        const iterator = await this.iterateOnVisibleFaces(patchStart, patchEnd);
+
         const patchSize = patchEnd.clone().sub(patchStart);
         const voxelsCountPerPatch = patchSize.x * patchSize.y * patchSize.z;
 
@@ -36,7 +38,6 @@ class PatchFactoryCpu extends PatchFactory {
         };
 
         const faceVerticesData = new Uint32Array(4 * uint32PerVertex);
-        const iterator = await this.iterateOnVisibleFaces(patchStart, patchEnd);
         for (const faceData of iterator()) {
             faceData.verticesData.forEach((faceVertexData: VertexData, faceVertexIndex: number) => {
                 faceVerticesData[faceVertexIndex] = PatchFactory.vertexDataEncoder.encode(

--- a/src/lib/terrain/patch/patch-factory/split/cpu/patch-factory-cpu.ts
+++ b/src/lib/terrain/patch/patch-factory/split/cpu/patch-factory-cpu.ts
@@ -41,7 +41,8 @@ class PatchFactoryCpu extends PatchFactory {
         };
 
         const faceVerticesData = new Uint32Array(4 * uint32PerVertex);
-        for (const faceData of this.iterateOnVisibleFaces(patchStart, patchEnd)) {
+        const iterator = await this.iterateOnVisibleFaces(patchStart, patchEnd);
+        for (const faceData of iterator()) {
             faceData.verticesData.forEach((faceVertexData: VertexData, faceVertexIndex: number) => {
                 faceVerticesData[faceVertexIndex] = PatchFactory.vertexDataEncoder.encode(
                     faceData.voxelLocalPosition.x,

--- a/src/lib/terrain/patch/patch-factory/split/cpu/patch-factory-cpu.ts
+++ b/src/lib/terrain/patch/patch-factory/split/cpu/patch-factory-cpu.ts
@@ -4,11 +4,8 @@ import * as Cube from '../../cube';
 import { type IVoxelMap } from '../../../../i-voxel-map';
 
 class PatchFactoryCpu extends PatchFactory {
-    public constructor(map: IVoxelMap, computingMode: EPatchComputingMode) {
-        if (computingMode !== EPatchComputingMode.CPU_CACHED) {
-            throw new Error();
-        }
-        super(map, computingMode);
+    public constructor(map: IVoxelMap) {
+        super(map, EPatchComputingMode.CPU_CACHED);
     }
 
     protected async computePatchData(patchStart: THREE.Vector3, patchEnd: THREE.Vector3): Promise<GeometryAndMaterial[]> {

--- a/src/lib/terrain/patch/patch-factory/split/cpu/patch-factory-cpu.ts
+++ b/src/lib/terrain/patch/patch-factory/split/cpu/patch-factory-cpu.ts
@@ -12,10 +12,8 @@ class PatchFactoryCpu extends PatchFactory {
     }
 
     protected async computePatchData(patchStart: THREE.Vector3, patchEnd: THREE.Vector3): Promise<GeometryAndMaterial[]> {
-        const voxelsCountPerPatch = this.map.getMaxVoxelsCount(patchStart, patchEnd);
-        if (voxelsCountPerPatch <= 0) {
-            return [];
-        }
+        const patchSize = patchEnd.clone().sub(patchStart);
+        const voxelsCountPerPatch = patchSize.x * patchSize.y * patchSize.z;
 
         type BufferData = {
             readonly buffer: Uint32Array;
@@ -60,7 +58,7 @@ class PatchFactoryCpu extends PatchFactory {
             }
         }
 
-        const truncateFaceBufferData = (bufferData: BufferData) => bufferData.buffer.subarray(0, bufferData.verticesCount);
+        const truncateFaceBufferData = (bufferData: BufferData) => new Uint32Array(bufferData.buffer.subarray(0, bufferData.verticesCount));
 
         const buffers: Record<Cube.FaceType, Uint32Array> = {
             up: truncateFaceBufferData(facesBufferData.up),

--- a/src/lib/terrain/patch/patch-factory/split/gpu/patch-factory-gpu-sequential.ts
+++ b/src/lib/terrain/patch/patch-factory/split/gpu/patch-factory-gpu-sequential.ts
@@ -20,7 +20,7 @@ class PatchFactoryGpuSequential extends PatchFactoryGpu {
                 return [];
             }
 
-            const localMapCache = this.buildLocalMapCache(patchStart, patchEnd);
+            const localMapCache = await this.buildLocalMapCache(patchStart, patchEnd);
             if (localMapCache.isEmpty) {
                 return [];
             }

--- a/src/lib/terrain/patch/patch-factory/split/patch-factory.ts
+++ b/src/lib/terrain/patch/patch-factory/split/patch-factory.ts
@@ -1,8 +1,8 @@
 import * as THREE from '../../../../three-usage';
-import { IVoxelMap } from '../../../i-voxel-map';
-import { EDisplayMode, PatchMaterial, PatchMaterialUniforms, PatchMaterials } from '../../material';
+import { type IVoxelMap } from '../../../i-voxel-map';
+import { EDisplayMode, type PatchMaterial, type PatchMaterialUniforms, type PatchMaterials } from '../../material';
 import * as Cube from '../cube';
-import { EPatchComputingMode, GeometryAndMaterial, PatchFactoryBase } from '../patch-factory-base';
+import { EPatchComputingMode, type GeometryAndMaterial, PatchFactoryBase } from '../patch-factory-base';
 
 import { VertexDataEncoder } from './vertex-data-encoder';
 

--- a/src/lib/terrain/patch/patch.ts
+++ b/src/lib/terrain/patch/patch.ts
@@ -1,6 +1,6 @@
 import * as THREE from '../../three-usage';
 
-import { EDisplayMode, PatchMaterials } from './material';
+import { EDisplayMode, type PatchMaterials } from './material';
 
 type PatchMesh = {
     readonly mesh: THREE.Mesh;

--- a/src/lib/terrain/terrain.ts
+++ b/src/lib/terrain/terrain.ts
@@ -55,7 +55,7 @@ class Terrain {
      * @param map The map that will be rendered.
      */
     public constructor(map: IVoxelMap, options?: TerrainOptions) {
-        let computingMode = EPatchComputingMode.GPU_OPTIMIZED;
+        let computingMode = EPatchComputingMode.CPU_CACHED;
         if (options) {
             if (typeof options.computingMode !== 'undefined') {
                 computingMode = options.computingMode;

--- a/src/lib/terrain/terrain.ts
+++ b/src/lib/terrain/terrain.ts
@@ -55,7 +55,7 @@ class Terrain {
      * @param map The map that will be rendered.
      */
     public constructor(map: IVoxelMap, options?: TerrainOptions) {
-        let computingMode = EPatchComputingMode.CPU_CACHED;
+        let computingMode = EPatchComputingMode.GPU_OPTIMIZED;
         if (options) {
             if (typeof options.computingMode !== 'undefined') {
                 computingMode = options.computingMode;

--- a/src/lib/terrain/terrain.ts
+++ b/src/lib/terrain/terrain.ts
@@ -62,7 +62,7 @@ class Terrain {
             }
         }
 
-        if (computingMode === EPatchComputingMode.CPU_SIMPLE || computingMode === EPatchComputingMode.CPU_CACHED) {
+        if (computingMode === EPatchComputingMode.CPU_CACHED) {
             this.patchFactory = new PatchFactoryCpu(map, computingMode);
         } else if (computingMode === EPatchComputingMode.GPU_SEQUENTIAL) {
             this.patchFactory = new PatchFactoryGpuSequential(map);

--- a/src/lib/terrain/terrain.ts
+++ b/src/lib/terrain/terrain.ts
@@ -63,7 +63,7 @@ class Terrain {
         }
 
         if (computingMode === EPatchComputingMode.CPU_CACHED) {
-            this.patchFactory = new PatchFactoryCpu(map, computingMode);
+            this.patchFactory = new PatchFactoryCpu(map);
         } else if (computingMode === EPatchComputingMode.GPU_SEQUENTIAL) {
             this.patchFactory = new PatchFactoryGpuSequential(map);
         } else if (computingMode === EPatchComputingMode.GPU_OPTIMIZED) {

--- a/src/lib/terrain/terrain.ts
+++ b/src/lib/terrain/terrain.ts
@@ -2,7 +2,7 @@ import { logger } from '../helpers/logger';
 import * as THREE from '../three-usage';
 
 import { AsyncPatch } from './async-patch';
-import { IVoxelMap } from './i-voxel-map';
+import { type IVoxelMap } from './i-voxel-map';
 import { EDisplayMode } from './patch/patch';
 import { EPatchComputingMode, PatchFactoryBase } from './patch/patch-factory/patch-factory-base';
 import { PatchFactoryCpu } from './patch/patch-factory/split/cpu/patch-factory-cpu';

--- a/src/lib/three-usage.ts
+++ b/src/lib/three-usage.ts
@@ -14,4 +14,5 @@ export {
     type Material,
     Uint32BufferAttribute,
     Vector3,
+    type Vector3Like,
 } from 'three';

--- a/src/test/voxel-map.ts
+++ b/src/test/voxel-map.ts
@@ -74,13 +74,7 @@ class VoxelMap implements IVoxelMap {
     }
 
     public getMaxVoxelsCount(from: THREE.Vector3, to: THREE.Vector3): number {
-        const fromX = Math.max(from.x, 0);
-        const fromZ = Math.max(from.z, 0);
-
-        const toX = Math.min(to.x, this.size.x);
-        const toZ = Math.min(to.z, this.size.z);
-
-        return (toX - fromX) * (toZ - fromZ);
+        return (to.x - from.x) * (to.z - from.z);
     }
 
     public *iterateOnVoxels(from: THREE.Vector3, to: THREE.Vector3): Generator<IVoxel> {

--- a/src/test/voxel-map.ts
+++ b/src/test/voxel-map.ts
@@ -78,13 +78,11 @@ class VoxelMap implements IVoxelMap {
         console.log(`Generated map of size ${this.size.x}x${this.size.y}x${this.size.z} (${this.voxels.length.toLocaleString()} voxels)`);
     }
 
-    public async getLocalMapData(patchStart: THREE.Vector3, patchEnd: THREE.Vector3): Promise<ILocalMapData> {
-        const cacheStart = patchStart.clone().subScalar(1);
-        const cacheEnd = patchEnd.clone().addScalar(1);
-        const cacheSize = new THREE.Vector3().subVectors(cacheEnd, cacheStart);
-        const cache = new Uint16Array(cacheSize.x * cacheSize.y * cacheSize.z);
+    public async getLocalMapData(blockStart: THREE.Vector3, blockEnd: THREE.Vector3): Promise<ILocalMapData> {
+        const blockSize = new THREE.Vector3().subVectors(blockEnd, blockStart);
+        const cache = new Uint16Array(blockSize.x * blockSize.y * blockSize.z);
 
-        const indexFactor = { x: 1, y: cacheSize.x, z: cacheSize.x * cacheSize.y };
+        const indexFactor = { x: 1, y: blockSize.x, z: blockSize.x * blockSize.y };
 
         const buildIndex = (position: THREE.Vector3) => {
             if (position.x < 0 || position.y < 0 || position.z < 0) {
@@ -94,8 +92,8 @@ class VoxelMap implements IVoxelMap {
         };
 
         let isEmpty = true;
-        for (const voxel of this.iterateOnVoxels(cacheStart, cacheEnd)) {
-            const localPosition = new THREE.Vector3().subVectors(voxel.position, cacheStart);
+        for (const voxel of this.iterateOnVoxels(blockStart, blockEnd)) {
+            const localPosition = new THREE.Vector3().subVectors(voxel.position, blockStart);
             const cacheIndex = buildIndex(localPosition);
             cache[cacheIndex] = 1 + voxel.materialId;
             isEmpty = false;

--- a/src/test/voxel-map.ts
+++ b/src/test/voxel-map.ts
@@ -73,10 +73,6 @@ class VoxelMap implements IVoxelMap {
         console.log(`Generated map of size ${this.size.x}x${this.size.y}x${this.size.z} (${this.voxels.length.toLocaleString()} voxels)`);
     }
 
-    public getMaxVoxelsCount(from: THREE.Vector3, to: THREE.Vector3): number {
-        return (to.x - from.x) * (to.z - from.z);
-    }
-
     public *iterateOnVoxels(from: THREE.Vector3, to: THREE.Vector3): Generator<IVoxel> {
         if (to.x < from.x || to.y < from.y || to.z < from.z) {
             throw new Error();


### PR DESCRIPTION
This PR drastically changes the way the  `Terrain` interacts with the `IVoxelMap`.

The `Terrain` now asks for chunks of the map when needed.

The `IVoxelMap` now only requires one method:
`getLocalMapData(from: Vector3Like, to: Vector3Like): Promise<ILocalMapData>;`
that returns the data for a portion of the map.

The `ILocalMapData` is defined as follows:
```ts
/** Compact object storing a portion of the map data  */
interface ILocalMapData {
    /** Compact array storing the voxel data.
     * Each element in the array represent a coordinate in the map and stores the data of the voxel at these coordinates.
     * An element:
     * - should be equal to 0 if there is no voxel at these coordinates
     * - should be equal to the voxel's material id + 1 if there is a voxel at these coordinates
     * 
     * The elements should be ordered by coordinates as follow by Z first, then Y then X.
     * For example, for a portion of the map between (0,0,0) and (2,2,2): (0,0,0) then (1,0,0) then (0,1,0) then (1,1,0) then (0,1,1) then (1,1,1)
    */
    readonly data: Uint16Array;

    /** Should be:
     * - true if there are no voxels in the data
     * - false if there is at least one voxel in the data
     */
    readonly isEmpty: boolean;
}
```