### PR TITLE
Fix/improve showmaparoundposition performance

### DIFF
--- a/src/lib/terrain/terrain.ts
+++ b/src/lib/terrain/terrain.ts
@@ -223,6 +223,7 @@ class Terrain {
         const patch = this.patches[patchId];
         if (patch) {
             patch.dispose();
+            logger.diagnostic(`Freeing patch ${patchId}`);
             delete this.patches[patchId];
         } else {
             logger.warn(`Patch ${patchId} does not exist.`);
@@ -241,6 +242,8 @@ class Terrain {
             patch = new AsyncPatch(this.container, promise, patchId, boundingBox);
 
             this.patches[patchId] = patch;
+
+            logger.diagnostic(`Building patch ${patchId}`);
         }
         return patch;
     }

--- a/src/lib/terrain/terrain.ts
+++ b/src/lib/terrain/terrain.ts
@@ -215,7 +215,8 @@ class Terrain {
             if (!nextPatchToDelete) {
                 break;
             }
-            this.disposePatch(nextPatchToDelete[0]);
+            const nextPatchIdToDelete = nextPatchToDelete[0];
+            this.disposePatch(nextPatchIdToDelete);
         }
     }
 

--- a/src/test/main.ts
+++ b/src/test/main.ts
@@ -29,7 +29,7 @@ udpateRendererSize();
 
 const scene = new THREE.Scene();
 
-const voxelMap = new VoxelMap(512, 512, 16);
+const voxelMap = new VoxelMap(4096, 4096, 16);
 const terrain = new Terrain(voxelMap);
 scene.add(terrain.container);
 
@@ -37,20 +37,21 @@ scene.add(new THREE.AxesHelper(500));
 
 camera.position.set(-50, 100, 50);
 const cameraControl = new OrbitControls(camera, renderer.domElement);
-cameraControl.target.set(voxelMap.size.x / 2, 0, voxelMap.size.z / 2);
+cameraControl.target.set(0, 0, 0);
 
-const playerViewRadius = 40;
+const playerViewRadius = 250;
 const playerContainer = new THREE.Group();
-playerContainer.position.x = voxelMap.size.x / 2;
+playerContainer.position.x = 0;
 playerContainer.position.y = voxelMap.size.y + 1;
-playerContainer.position.z = voxelMap.size.z / 2;
+playerContainer.position.z = 0;
 const player = new THREE.Mesh(new THREE.SphereGeometry(2), new THREE.MeshBasicMaterial({ color: '#FF0000' }));
 playerContainer.add(player);
 scene.add(playerContainer);
 
 const showWholeMap = true;
 if (showWholeMap) {
-    terrain.showMapPortion(new THREE.Box3(new THREE.Vector3(-256, -256, -256), new THREE.Vector3(256, 256, 256)));
+    const size = 250;
+    terrain.showMapPortion(new THREE.Box3(new THREE.Vector3(-size, -size, -size), new THREE.Vector3(size, size, size)));
 } else {
     const playerViewSphere = new THREE.Mesh(
         new THREE.SphereGeometry(playerViewRadius, 16, 16),


### PR DESCRIPTION
This PR fixes a bug where when called several times,`Terrain.showMapAroundPosition()` kept freeing and rebuilding the same patches over and over if the cache was too small.