### PR TITLE
Feat/reduce drawcalls

### DIFF
--- a/src/lib/terrain/patch/patch-factory/cube.ts
+++ b/src/lib/terrain/patch/patch-factory/cube.ts
@@ -45,7 +45,7 @@ function buildNormal(vec: THREE.Vector3): Normal {
             };
         }
     }
-    throw new Error("Invalid normal");
+    throw new Error('Invalid normal');
 }
 
 type Face = {

--- a/src/lib/terrain/patch/patch-factory/cube.ts
+++ b/src/lib/terrain/patch/patch-factory/cube.ts
@@ -29,14 +29,32 @@ const normals: Record<FaceType, THREE.Vector3> = {
     front: new THREE.Vector3(0, 0, +1),
     back: new THREE.Vector3(0, 0, -1),
 };
+const normalsById = Object.values(normals);
+
+type Normal = {
+    readonly id: number;
+    readonly vec: THREE.Vector3;
+};
+
+function buildNormal(vec: THREE.Vector3): Normal {
+    for (let i = 0; i < normalsById.length; i++) {
+        if (normalsById[i]!.equals(vec)) {
+            return {
+                id: i,
+                vec,
+            };
+        }
+    }
+    throw new Error("Invalid normal");
+}
 
 type Face = {
     readonly id: number;
     readonly type: FaceType;
     readonly vertices: [FaceVertex, FaceVertex, FaceVertex, FaceVertex];
-    readonly normal: THREE.Vector3;
-    readonly uvUp: THREE.Vector3;
-    readonly uvRight: THREE.Vector3;
+    readonly normal: Normal;
+    readonly uvUp: Normal;
+    readonly uvRight: Normal;
 };
 
 const faceIndices: [number, number, number, number, number, number] = [0, 2, 1, 1, 2, 3];
@@ -103,9 +121,9 @@ function buildFace(type: FaceType, v00: THREE.Vector3, v01: THREE.Vector3, v10: 
                 },
             },
         ],
-        normal,
-        uvUp,
-        uvRight,
+        normal: buildNormal(normal),
+        uvUp: buildNormal(uvUp),
+        uvRight: buildNormal(uvRight),
     };
 }
 
@@ -119,4 +137,4 @@ const faces: Record<FaceType, Face> = {
 };
 const facesById = Object.values(faces).sort((face1: Face, face2: Face) => face1.id - face2.id);
 
-export { faceIndices, faces, facesById, type FaceType, type FaceVertex };
+export { faceIndices, faces, facesById, normalsById, type Face, type FaceType, type FaceVertex };

--- a/src/lib/terrain/patch/patch-factory/merged/cpu/patch-factory-cpu.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/cpu/patch-factory-cpu.ts
@@ -15,27 +15,14 @@ class PatchFactoryCpu extends PatchFactory {
         const patchSize = patchEnd.clone().sub(patchStart);
         const voxelsCountPerPatch = patchSize.x * patchSize.y * patchSize.z;
 
-        type BufferData = {
-            readonly buffer: Uint32Array;
-            verticesCount: number;
-        };
-
+        const maxFacesPerVoxel = 6;
         const verticesPerFace = 6;
         const uint32PerVertex = 2;
-        const bufferLength = voxelsCountPerPatch * verticesPerFace * uint32PerVertex;
-        const buildFaceBufferData = () => {
-            return {
-                buffer: new Uint32Array(bufferLength),
-                verticesCount: 0,
-            };
-        };
-        const facesBufferData: Record<Cube.FaceType, BufferData> = {
-            up: buildFaceBufferData(),
-            down: buildFaceBufferData(),
-            left: buildFaceBufferData(),
-            right: buildFaceBufferData(),
-            front: buildFaceBufferData(),
-            back: buildFaceBufferData(),
+        const bufferLength = maxFacesPerVoxel * voxelsCountPerPatch * verticesPerFace * uint32PerVertex;
+
+        const bufferData = {
+            buffer: new Uint32Array(bufferLength),
+            verticesCount: 0,
         };
 
         let faceId = 0;
@@ -59,26 +46,15 @@ class PatchFactoryCpu extends PatchFactory {
                 );
             });
 
-            const faceBufferData = facesBufferData[faceData.faceType];
             for (const index of Cube.faceIndices) {
-                const vertexIndex = uint32PerVertex * (faceBufferData.verticesCount++);
-                faceBufferData.buffer[vertexIndex] = faceVerticesData[2 * index + 0]!;
-                faceBufferData.buffer[vertexIndex + 1] = faceVerticesData[2 * index + 1]!;
+                const vertexIndex = uint32PerVertex * (bufferData.verticesCount++);
+                bufferData.buffer[vertexIndex] = faceVerticesData[2 * index + 0]!;
+                bufferData.buffer[vertexIndex + 1] = faceVerticesData[2 * index + 1]!;
             }
         }
 
-        const truncateFaceBufferData = (bufferData: BufferData) => new Uint32Array(bufferData.buffer.subarray(0, uint32PerVertex * bufferData.verticesCount));
-
-        const buffers: Record<Cube.FaceType, Uint32Array> = {
-            up: truncateFaceBufferData(facesBufferData.up),
-            down: truncateFaceBufferData(facesBufferData.down),
-            left: truncateFaceBufferData(facesBufferData.left),
-            right: truncateFaceBufferData(facesBufferData.right),
-            front: truncateFaceBufferData(facesBufferData.front),
-            back: truncateFaceBufferData(facesBufferData.back),
-        };
-
-        return this.assembleGeometryAndMaterials(buffers);
+        const buffer = new Uint32Array(bufferData.buffer.subarray(0, uint32PerVertex * bufferData.verticesCount));
+        return this.assembleGeometryAndMaterials(buffer);
     }
 }
 

--- a/src/lib/terrain/patch/patch-factory/merged/cpu/patch-factory-cpu.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/cpu/patch-factory-cpu.ts
@@ -1,0 +1,78 @@
+import * as THREE from '../../../../../three-usage';
+import { type IVoxelMap } from '../../../../i-voxel-map';
+import * as Cube from '../../cube';
+import { EPatchComputingMode, type GeometryAndMaterial, type VertexData } from '../../patch-factory-base';
+import { PatchFactory } from '../patch-factory';
+
+class PatchFactoryCpu extends PatchFactory {
+    public constructor(map: IVoxelMap) {
+        super(map, EPatchComputingMode.CPU_CACHED);
+    }
+
+    protected async computePatchData(patchStart: THREE.Vector3, patchEnd: THREE.Vector3): Promise<GeometryAndMaterial[]> {
+        const iterator = await this.iterateOnVisibleFaces(patchStart, patchEnd);
+
+        const patchSize = patchEnd.clone().sub(patchStart);
+        const voxelsCountPerPatch = patchSize.x * patchSize.y * patchSize.z;
+
+        type BufferData = {
+            readonly buffer: Uint32Array;
+            verticesCount: number;
+        };
+
+        const verticesPerFace = 6;
+        const uint32PerVertex = 2;
+        const bufferLength = voxelsCountPerPatch * verticesPerFace * uint32PerVertex;
+        const buildFaceBufferData = () => {
+            return {
+                buffer: new Uint32Array(bufferLength),
+                verticesCount: 0,
+            };
+        };
+        const facesBufferData: Record<Cube.FaceType, BufferData> = {
+            up: buildFaceBufferData(),
+            down: buildFaceBufferData(),
+            left: buildFaceBufferData(),
+            right: buildFaceBufferData(),
+            front: buildFaceBufferData(),
+            back: buildFaceBufferData(),
+        };
+
+        const faceVerticesData = new Uint32Array(4 * uint32PerVertex);
+        for (const faceData of iterator()) {
+            faceData.verticesData.forEach((faceVertexData: VertexData, faceVertexIndex: number) => {
+                faceVerticesData[2 * faceVertexIndex + 0] = PatchFactory.vertexData1Encoder.encode(
+                    faceData.voxelLocalPosition.x,
+                    faceData.voxelLocalPosition.y,
+                    faceData.voxelLocalPosition.z,
+                    // faceData.voxelMaterialId,
+                    faceVertexData.ao,
+                    [faceVertexData.roundnessX, faceVertexData.roundnessY]
+                );
+                faceVerticesData[2 * faceVertexIndex + 1] = PatchFactory.vertexData2Encoder.encode(
+                    faceData.voxelMaterialId
+                );
+            });
+
+            const faceBufferData = facesBufferData[faceData.faceType];
+            for (const index of Cube.faceIndices) {
+                faceBufferData.buffer[faceBufferData.verticesCount++] = faceVerticesData[index]!;
+            }
+        }
+
+        const truncateFaceBufferData = (bufferData: BufferData) => new Uint32Array(bufferData.buffer.subarray(0, bufferData.verticesCount));
+
+        const buffers: Record<Cube.FaceType, Uint32Array> = {
+            up: truncateFaceBufferData(facesBufferData.up),
+            down: truncateFaceBufferData(facesBufferData.down),
+            left: truncateFaceBufferData(facesBufferData.left),
+            right: truncateFaceBufferData(facesBufferData.right),
+            front: truncateFaceBufferData(facesBufferData.front),
+            back: truncateFaceBufferData(facesBufferData.back),
+        };
+
+        return this.assembleGeometryAndMaterials(buffers);
+    }
+}
+
+export { PatchFactoryCpu };

--- a/src/lib/terrain/patch/patch-factory/merged/cpu/patch-factory-cpu.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/cpu/patch-factory-cpu.ts
@@ -45,9 +45,8 @@ class PatchFactoryCpu extends PatchFactory {
 
             faceData.verticesData.forEach((faceVertexData: VertexData, faceVertexIndex: number) => {
                 faceVerticesData[2 * faceVertexIndex + 0] = PatchFactory.vertexData1Encoder.encode(
-                    faceData.voxelLocalPosition.x,
-                    faceData.voxelLocalPosition.y,
-                    faceData.voxelLocalPosition.z,
+                    faceData.voxelLocalPosition,
+                    faceVertexData.localPosition,
                     faceVertexData.ao,
                     [faceVertexData.roundnessX, faceVertexData.roundnessY]
                 );

--- a/src/lib/terrain/patch/patch-factory/merged/cpu/patch-factory-cpu.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/cpu/patch-factory-cpu.ts
@@ -47,12 +47,15 @@ class PatchFactoryCpu extends PatchFactory {
                 faceVerticesData[2 * faceVertexIndex + 0] = PatchFactory.vertexData1Encoder.encode(
                     faceData.voxelLocalPosition,
                     faceVertexData.localPosition,
+                    faceData.faceId,
                     faceVertexData.ao,
                     [faceVertexData.roundnessX, faceVertexData.roundnessY]
                 );
                 faceVerticesData[2 * faceVertexIndex + 1] = PatchFactory.vertexData2Encoder.encode(
                     faceData.voxelMaterialId,
                     faceNoiseId,
+                    Cube.faces[faceData.faceType].normal.id,
+                    Cube.faces[faceData.faceType].uvRight.id,
                 );
             });
 

--- a/src/lib/terrain/patch/patch-factory/merged/cpu/patch-factory-cpu.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/cpu/patch-factory-cpu.ts
@@ -28,7 +28,7 @@ class PatchFactoryCpu extends PatchFactory {
         let faceId = 0;
         const faceVerticesData = new Uint32Array(uint32PerVertex * 4);
         for (const faceData of iterator()) {
-            const faceNoiseId = (faceId++) % PatchFactory.vertexData2Encoder.faceNoiseId.maxValue;
+            const faceNoiseId = faceId++ % PatchFactory.vertexData2Encoder.faceNoiseId.maxValue;
 
             faceData.verticesData.forEach((faceVertexData: VertexData, faceVertexIndex: number) => {
                 faceVerticesData[2 * faceVertexIndex + 0] = PatchFactory.vertexData1Encoder.encode(
@@ -42,12 +42,12 @@ class PatchFactoryCpu extends PatchFactory {
                     faceData.voxelMaterialId,
                     faceNoiseId,
                     Cube.faces[faceData.faceType].normal.id,
-                    Cube.faces[faceData.faceType].uvRight.id,
+                    Cube.faces[faceData.faceType].uvRight.id
                 );
             });
 
             for (const index of Cube.faceIndices) {
-                const vertexIndex = uint32PerVertex * (bufferData.verticesCount++);
+                const vertexIndex = uint32PerVertex * bufferData.verticesCount++;
                 bufferData.buffer[vertexIndex] = faceVerticesData[2 * index + 0]!;
                 bufferData.buffer[vertexIndex + 1] = faceVerticesData[2 * index + 1]!;
             }

--- a/src/lib/terrain/patch/patch-factory/merged/gpu/patch-computer-gpu.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/gpu/patch-computer-gpu.ts
@@ -78,8 +78,8 @@ class PatchComputerGpu {
         fn encodeVertexData1(encodedVoxelPosition: u32, verticePosition: vec3u, ao: u32, edgeRoundnessX: u32, edgeRoundnessY: u32) -> u32 {
             return encodedVoxelPosition + ${vertexData1Encoder.wgslEncodeVertexData('verticePosition', 'ao', 'edgeRoundnessX', 'edgeRoundnessY')};
         }
-        fn encodeVoxelData2(voxelMaterialId: u32, faceNoiseId: u32) -> u32 {
-            return ${vertexData2Encoder.wgslEncodeVoxelData('voxelMaterialId', 'faceNoiseId')};
+        fn encodeVoxelData2(voxelMaterialId: u32, faceNoiseId: u32, normalId: u32, uvRightId: u32) -> u32 {
+            return ${vertexData2Encoder.wgslEncodeVoxelData('voxelMaterialId', 'faceNoiseId', 'normalId', 'uvRightId')};
         }
 
         @compute @workgroup_size(${this.workgroupSize})
@@ -113,7 +113,7 @@ class PatchComputerGpu {
                     ${Object.values(Cube.faces)
                 .map(
                     face => `
-                    if (!doesNeighbourExist(cacheIndex, vec3i(${face.normal.x}, ${face.normal.y}, ${face.normal.z}))) {
+                    if (!doesNeighbourExist(cacheIndex, vec3i(${face.normal.vec.x}, ${face.normal.vec.y}, ${face.normal.vec.z}))) {
                         let firstVertexIndex: u32 = atomicAdd(&${face.type}FaceVerticesData.verticesCount, 6u);
                         let faceNoiseId: u32 = (firstVertexIndex / 6u) % (${vertexData2Encoder.faceNoiseId.maxValue});
                         var ao: u32;
@@ -150,7 +150,7 @@ class PatchComputerGpu {
                             .map(
                                 (faceVertexId: number, index: number) => `
                         ${face.type}FaceVerticesData.verticesData[2u * (firstVertexIndex + ${index}u) + 0u] = vertex${faceVertexId}Data;
-                        ${face.type}FaceVerticesData.verticesData[2u * (firstVertexIndex + ${index}u) + 1u] = encodeVoxelData2(voxelMaterialId, faceNoiseId);`
+                        ${face.type}FaceVerticesData.verticesData[2u * (firstVertexIndex + ${index}u) + 1u] = encodeVoxelData2(voxelMaterialId, faceNoiseId, ${face.normal.id}u, ${face.uvRight.id}u);`
                             )
                             .join('')}
                     }`

--- a/src/lib/terrain/patch/patch-factory/merged/gpu/patch-computer-gpu.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/gpu/patch-computer-gpu.ts
@@ -1,0 +1,298 @@
+/// <reference types="@webgpu/types" />
+
+import * as THREE from 'three';
+
+import { logger } from '../../../../../helpers/logger';
+import { getGpuDevice } from '../../../../../helpers/webgpu/webgpu-device';
+import * as Cube from '../../cube';
+import { type LocalMapCache } from '../../patch-factory-base';
+import { VertexData1Encoder } from '../vertex-data1-encoder';
+import { VertexData2Encoder } from '../vertex-data2-encoder';
+
+type FaceBuffer = {
+    readonly storageBuffer: GPUBuffer;
+    readonly readableBuffer: GPUBuffer;
+};
+
+type ComputationOutputs = Record<Cube.FaceType, Uint32Array>;
+
+class PatchComputerGpu {
+    public static async create(localCacheSize: THREE.Vector3, vertexData1Encoder: VertexData1Encoder, vertexData2Encoder: VertexData2Encoder): Promise<PatchComputerGpu> {
+        logger.debug('Requesting WebGPU device...');
+        const device = await getGpuDevice();
+        return new PatchComputerGpu(device, localCacheSize, vertexData1Encoder, vertexData2Encoder);
+    }
+
+    private readonly device: GPUDevice;
+
+    private readonly computePipeline: GPUComputePipeline;
+    private readonly computePipelineBindgroup: GPUBindGroup;
+    private readonly localCacheBuffer: GPUBuffer;
+    private readonly faceBuffers: Record<Cube.FaceType, FaceBuffer>;
+
+    private readonly workgroupSize = 256;
+
+    private constructor(device: GPUDevice, localCacheSize: THREE.Vector3, vertexData1Encoder: VertexData1Encoder, vertexData2Encoder: VertexData2Encoder) {
+        this.device = device;
+
+        const code = `
+        struct LocalMapCacheBuffer {
+            size: vec3i,
+            data: array<u32>,
+        };
+        struct FaceVerticesBuffer {
+            verticesCount: atomic<u32>,
+            verticesData: array<u32>,
+        };
+        @group(0) @binding(0) var<storage,read> localMapCacheData: LocalMapCacheBuffer;
+        @group(0) @binding(1) var<storage,read_write> upFaceVerticesData: FaceVerticesBuffer;
+        @group(0) @binding(2) var<storage,read_write> downFaceVerticesData: FaceVerticesBuffer;
+        @group(0) @binding(3) var<storage,read_write> leftFaceVerticesData: FaceVerticesBuffer;
+        @group(0) @binding(4) var<storage,read_write> rightFaceVerticesData: FaceVerticesBuffer;
+        @group(0) @binding(5) var<storage,read_write> frontFaceVerticesData: FaceVerticesBuffer;
+        @group(0) @binding(6) var<storage,read_write> backFaceVerticesData: FaceVerticesBuffer;
+        struct ComputeIn {
+            @builtin(global_invocation_id) globalInvocationId : vec3<u32>,
+        };
+        
+        fn sampleLocalCache(index: i32) -> u32 {
+            let actualIndex = index / 2;
+            let data = localMapCacheData.data[actualIndex];
+            if (index % 2 == 0) {
+                return data & ${(1 << 16) - 1};
+            } else {
+                return data >> 16;
+            }
+        }
+        fn buildCacheIndex(coords: vec3i) -> i32 {
+            return coords.x + localMapCacheData.size.x * (coords.y + localMapCacheData.size.y * coords.z);
+        }
+        fn doesNeighbourExist(voxelCacheIndex: i32, neighbourRelativePosition: vec3i) -> bool {
+            let neighbourCacheIndex = voxelCacheIndex + buildCacheIndex(neighbourRelativePosition);
+            let neighbourData = sampleLocalCache(neighbourCacheIndex);
+            return neighbourData != 0u;
+        }
+        fn encodeVoxelData1(localPositionX: u32, localPositionY: u32, localPositionZ: u32) -> u32 {
+            return ${vertexData1Encoder.wgslEncodeVoxelData('localPositionX', 'localPositionY', 'localPositionZ')};
+        }
+        fn encodeVoxelData2(voxelMaterialId: u32) -> u32 {
+            return ${vertexData2Encoder.wgslEncodeVoxelData('voxelMaterialId')};
+        }
+        fn encodeVertexData(voxelData: u32, ao: u32, edgeRoundnessX: u32, edgeRoundnessY: u32) -> u32 {
+            return voxelData + ${vertexData1Encoder.wgslEncodeVertexData('ao', 'edgeRoundnessX', 'edgeRoundnessY')};
+        }
+        @compute @workgroup_size(${this.workgroupSize})
+        fn main(in: ComputeIn) {
+            let globalInvocationId: u32 = in.globalInvocationId.x;
+            if (globalInvocationId == 0u) {
+                ${Object.values(Cube.faces)
+                    .map(
+                        face => `
+                atomicStore(&${face.type}FaceVerticesData.verticesCount, 0u);`
+                    )
+                    .join('')};
+            }
+            storageBarrier();
+            let patchIndex: u32 = globalInvocationId;
+        
+            let patchSize: vec3u = vec3u(localMapCacheData.size) - 2u;
+        
+            let voxelLocalPosition = vec3u(
+                patchIndex % patchSize.x,
+                (patchIndex / patchSize.x) % patchSize.y,
+                patchIndex / (patchSize.x * patchSize.y)
+            );
+            if (voxelLocalPosition.z < patchSize.z) { // if we are in the patch
+                let cacheCoords = vec3i(voxelLocalPosition + 1u);
+                let cacheIndex: i32 = buildCacheIndex(cacheCoords);
+                let voxelData: u32 = sampleLocalCache(cacheIndex);
+                if (voxelData != 0u) {
+                    let voxelMaterialId: u32 = voxelData - 1u;
+                    let voxelData = encodeVoxelData1(voxelLocalPosition.x, voxelLocalPosition.y, voxelLocalPosition.z);
+                    ${Object.values(Cube.faces)
+                        .map(
+                            face => `
+                    if (!doesNeighbourExist(cacheIndex, vec3i(${face.normal.x}, ${face.normal.y}, ${face.normal.z}))) {
+                        let firstVertexIndex: u32 = atomicAdd(&${face.type}FaceVerticesData.verticesCount, 12u);
+                        var ao: u32;
+                        var edgeRoundnessX: bool;
+                        var edgeRoundnessY: bool;
+                        ${face.vertices
+                            .map(
+                                (faceVertex: Cube.FaceVertex, faceVertexId: number) => `
+                        ao = 0u;
+                        {
+                            let a: bool = doesNeighbourExist(cacheIndex, vec3i(${faceVertex.shadowingNeighbourVoxels[0].x},${
+                                faceVertex.shadowingNeighbourVoxels[0].y
+                            },${faceVertex.shadowingNeighbourVoxels[0].z}));
+                            let b: bool = doesNeighbourExist(cacheIndex, vec3i(${faceVertex.shadowingNeighbourVoxels[1].x},${
+                                faceVertex.shadowingNeighbourVoxels[1].y
+                            },${faceVertex.shadowingNeighbourVoxels[1].z}));
+                            let c: bool = doesNeighbourExist(cacheIndex, vec3i(${faceVertex.shadowingNeighbourVoxels[2].x},${
+                                faceVertex.shadowingNeighbourVoxels[2].y
+                            },${faceVertex.shadowingNeighbourVoxels[2].z}));
+                            if (a && b) {
+                                ao = 3u;
+                              } else {
+                                ao = u32(a) + u32(b) + u32(c);
+                              }
+                        }
+                        edgeRoundnessX = ${faceVertex.edgeNeighbourVoxels.x
+                            .map(neighbour => `!doesNeighbourExist(cacheIndex, vec3i(${neighbour.x},${neighbour.y},${neighbour.z}))`)
+                            .join(' && ')};
+                        edgeRoundnessY = ${faceVertex.edgeNeighbourVoxels.y
+                            .map(neighbour => `!doesNeighbourExist(cacheIndex, vec3i(${neighbour.x},${neighbour.y},${neighbour.z}))`)
+                            .join(' && ')};
+                        let vertex${faceVertexId}Data = encodeVertexData(voxelData, ao, u32(edgeRoundnessX), u32(edgeRoundnessY));`
+                            )
+                            .join('')}
+                        ${Cube.faceIndices
+                            .map(
+                                (faceVertexId: number, index: number) => `
+                        ${face.type}FaceVerticesData.verticesData[firstVertexIndex + ${2 * index}u + 0u] = vertex${faceVertexId}Data;
+                        ${face.type}FaceVerticesData.verticesData[firstVertexIndex + ${2 * index}u + 1u] = encodeVoxelData2(voxelMaterialId);`
+                            )
+                            .join('')}
+                    }`
+                        )
+                        .join('\n')}
+                }
+            }
+        }
+    `;
+        this.computePipeline = this.device.createComputePipeline({
+            compute: {
+                module: this.device!.createShaderModule({
+                    code,
+                }),
+                entryPoint: 'main',
+            },
+            layout: 'auto',
+        });
+
+        this.localCacheBuffer = this.device.createBuffer({
+            size:
+                Uint32Array.BYTES_PER_ELEMENT * 3 +
+                Uint16Array.BYTES_PER_ELEMENT * (localCacheSize.x * localCacheSize.y * localCacheSize.z),
+            usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+            mappedAtCreation: false,
+        });
+
+        const maxVoxelsCount = (localCacheSize.x - 2) * (localCacheSize.y - 2) * (localCacheSize.z - 2);
+        const verticesPerVoxel = 6;
+        const bufferSize = Uint32Array.BYTES_PER_ELEMENT * (1 + Math.ceil(maxVoxelsCount / 2) * verticesPerVoxel);
+
+        const buildFaceBuffer = () => {
+            return {
+                storageBuffer: this.device.createBuffer({
+                    size: bufferSize,
+                    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+                    mappedAtCreation: false,
+                }),
+                readableBuffer: this.device.createBuffer({
+                    size: bufferSize,
+                    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+                    mappedAtCreation: false,
+                }),
+            };
+        };
+
+        this.faceBuffers = {
+            up: buildFaceBuffer(),
+            down: buildFaceBuffer(),
+            left: buildFaceBuffer(),
+            right: buildFaceBuffer(),
+            front: buildFaceBuffer(),
+            back: buildFaceBuffer(),
+        };
+
+        let totalBuffersSize = 0;
+        Object.values(this.faceBuffers).forEach(
+            faceBuffer => (totalBuffersSize += faceBuffer.readableBuffer.size + faceBuffer.storageBuffer.size)
+        );
+        logger.info(`Allocated ${(totalBuffersSize / 1024 / 1024).toFixed(1)} MB of webgpu buffers.`);
+
+        const bindgroupBuffers = [this.localCacheBuffer, ...Object.values(this.faceBuffers).map(faceBuffer => faceBuffer.storageBuffer)];
+        this.computePipelineBindgroup = this.device.createBindGroup({
+            layout: this.computePipeline.getBindGroupLayout(0),
+            entries: bindgroupBuffers.map((buffer: GPUBuffer, index: number) => {
+                return {
+                    binding: index,
+                    resource: { buffer },
+                };
+            }),
+        });
+    }
+
+    public async computeBuffers(localMapCache: LocalMapCache): Promise<ComputationOutputs> {
+        this.device.queue.writeBuffer(
+            this.localCacheBuffer,
+            0,
+            new Int32Array([localMapCache.size.x, localMapCache.size.y, localMapCache.size.z])
+        );
+        this.device.queue.writeBuffer(this.localCacheBuffer, Int32Array.BYTES_PER_ELEMENT * 3, localMapCache.data);
+
+        const patchSize = localMapCache.size.clone().subScalar(2);
+        const totalPatchCells = patchSize.x * patchSize.y * patchSize.z;
+
+        const commandEncoder = this.device.createCommandEncoder();
+        const computePass = commandEncoder.beginComputePass();
+        computePass.setPipeline(this.computePipeline);
+        computePass.setBindGroup(0, this.computePipelineBindgroup);
+        computePass.dispatchWorkgroups(Math.ceil(totalPatchCells / this.workgroupSize));
+        computePass.end();
+
+        for (const faceBuffer of Object.values(this.faceBuffers)) {
+            commandEncoder.copyBufferToBuffer(faceBuffer.storageBuffer, 0, faceBuffer.readableBuffer, 0, faceBuffer.readableBuffer.size);
+        }
+
+        this.device.queue.submit([commandEncoder.finish()]);
+
+        const emptyArray = new Uint32Array();
+        const result = {
+            up: emptyArray,
+            down: emptyArray,
+            left: emptyArray,
+            right: emptyArray,
+            front: emptyArray,
+            back: emptyArray,
+        };
+
+        const promises = (Object.entries(this.faceBuffers) as [Cube.FaceType, FaceBuffer][]).map(
+            async (entry: [Cube.FaceType, FaceBuffer]) => {
+                const faceType = entry[0];
+                const faceBuffer = entry[1];
+
+                await faceBuffer.readableBuffer.mapAsync(GPUMapMode.READ);
+                const cpuBuffer = new Uint32Array(faceBuffer.readableBuffer.getMappedRange());
+
+                const verticesCount = cpuBuffer[0];
+                if (typeof verticesCount === 'undefined') {
+                    throw new Error();
+                }
+
+                const verticesDataBuffer = cpuBuffer.subarray(1, 1 + verticesCount);
+                const finalBuffer = new Uint32Array(verticesCount);
+                finalBuffer.set(verticesDataBuffer);
+                faceBuffer.readableBuffer.unmap();
+
+                result[faceType] = finalBuffer;
+            }
+        );
+
+        await Promise.all(promises);
+        return result;
+    }
+
+    public dispose(): void {
+        this.localCacheBuffer.destroy();
+        for (const buffer of Object.values(this.faceBuffers)) {
+            buffer.storageBuffer.destroy();
+            buffer.readableBuffer.destroy();
+        }
+        logger.debug('Destroying WebGPU device...');
+        this.device.destroy();
+    }
+}
+
+export { PatchComputerGpu, type ComputationOutputs };

--- a/src/lib/terrain/patch/patch-factory/merged/gpu/patch-factory-gpu-optimized.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/gpu/patch-factory-gpu-optimized.ts
@@ -1,0 +1,96 @@
+import * as THREE from '../../../../../three-usage';
+import { type IVoxelMap } from '../../../../i-voxel-map';
+import { EPatchComputingMode, type GeometryAndMaterial, type LocalMapCache } from '../../patch-factory-base';
+import { AsyncTask } from '../../../../../helpers/async-task';
+
+import { PatchFactoryGpu } from './patch-factory-gpu';
+
+type PatchGenerationJob = {
+    readonly patchId: number;
+    cpuTask: AsyncTask<LocalMapCache>;
+    gpuTask?: Promise<GeometryAndMaterial[]>;
+    readonly resolve: (value: GeometryAndMaterial[] | PromiseLike<GeometryAndMaterial[]>) => void;
+};
+
+class PatchFactoryGpuOptimized extends PatchFactoryGpu {
+    private nextPatchId = 0;
+
+    private readonly pendingJobs: PatchGenerationJob[] = [];
+
+    public constructor(map: IVoxelMap) {
+        super(map, EPatchComputingMode.GPU_OPTIMIZED);
+    }
+
+    protected computePatchData(patchStart: THREE.Vector3, patchEnd: THREE.Vector3): Promise<GeometryAndMaterial[]> {
+        const patchSize = new THREE.Vector3().subVectors(patchEnd, patchStart);
+        const voxelsCountPerPatch = patchSize.x * patchSize.y * patchSize.z;
+        if (voxelsCountPerPatch <= 0) {
+            return Promise.resolve([]);
+        }
+
+        return new Promise<GeometryAndMaterial[]>(resolve => {
+            const patchId = this.nextPatchId++;
+            // logger.diagnostic(`Asking for patch ${patchId}`);
+
+            this.pendingJobs.push({
+                patchId,
+                cpuTask: new AsyncTask<LocalMapCache>(async () => {
+                    // logger.diagnostic(`CPU ${patchId} start`);
+                    const result = await this.buildLocalMapCache(patchStart, patchEnd);
+                    // logger.diagnostic(`CPU ${patchId} end`);
+                    return result;
+                }),
+                resolve,
+            });
+
+            this.runNextTask();
+        });
+    }
+
+    private runNextTask(): void {
+        const currentJob = this.pendingJobs[0];
+        const runNextTask = () => {
+            this.runNextTask();
+        };
+
+        if (currentJob) {
+            if (!currentJob.cpuTask.isStarted) {
+                currentJob.cpuTask.start();
+                currentJob.cpuTask.awaitResult().then(runNextTask);
+            } else if (currentJob.cpuTask.isFinished) {
+                if (!currentJob.gpuTask) {
+                    const localMapCache = currentJob.cpuTask.getResultSync();
+
+                    if (localMapCache.isEmpty) {
+                        currentJob.gpuTask = Promise.resolve([]);
+                    } else {
+                        currentJob.gpuTask = (async () => {
+                            // logger.diagnostic(`GPU ${currentJob.patchId} start`);
+                            const patchComputerGpu = await this.getPatchComputerGpu();
+                            const gpuTaskOutput = await patchComputerGpu.computeBuffers(localMapCache);
+                            // logger.diagnostic(`GPU ${currentJob.patchId} end`);
+
+                            return this.assembleGeometryAndMaterials(gpuTaskOutput);
+                        })();
+                    }
+
+                    currentJob.gpuTask.then(result => {
+                        this.pendingJobs.shift();
+                        currentJob.resolve(result);
+                        this.runNextTask();
+                    });
+                }
+
+                const nextJob = this.pendingJobs[1];
+                if (nextJob) {
+                    if (!nextJob.cpuTask.isStarted) {
+                        nextJob.cpuTask.start();
+                        nextJob.cpuTask.awaitResult().then(runNextTask);
+                    }
+                }
+            }
+        }
+    }
+}
+
+export { PatchFactoryGpuOptimized };

--- a/src/lib/terrain/patch/patch-factory/merged/gpu/patch-factory-gpu-optimized.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/gpu/patch-factory-gpu-optimized.ts
@@ -67,7 +67,7 @@ class PatchFactoryGpuOptimized extends PatchFactoryGpu {
                         currentJob.gpuTask = (async () => {
                             // logger.diagnostic(`GPU ${currentJob.patchId} start`);
                             const patchComputerGpu = await this.getPatchComputerGpu();
-                            const gpuTaskOutput = await patchComputerGpu.computeBuffers(localMapCache);
+                            const gpuTaskOutput = await patchComputerGpu.computeBuffer(localMapCache);
                             // logger.diagnostic(`GPU ${currentJob.patchId} end`);
 
                             return this.assembleGeometryAndMaterials(gpuTaskOutput);

--- a/src/lib/terrain/patch/patch-factory/merged/gpu/patch-factory-gpu-sequential.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/gpu/patch-factory-gpu-sequential.ts
@@ -1,0 +1,35 @@
+import { PromiseThrottler } from '../../../../../helpers/promise-throttler';
+import { type IVoxelMap } from '../../../../i-voxel-map';
+import { EPatchComputingMode, type GeometryAndMaterial } from '../../patch-factory-base';
+import * as THREE from '../../../../../three-usage';
+
+import { PatchFactoryGpu } from './patch-factory-gpu';
+
+class PatchFactoryGpuSequential extends PatchFactoryGpu {
+    private readonly gpuSequentialLimiter = new PromiseThrottler(1);
+
+    public constructor(map: IVoxelMap) {
+        super(map, EPatchComputingMode.GPU_SEQUENTIAL);
+    }
+
+    protected computePatchData(patchStart: THREE.Vector3, patchEnd: THREE.Vector3): Promise<GeometryAndMaterial[]> {
+        return this.gpuSequentialLimiter.run(async () => {
+            const patchSize = new THREE.Vector3().subVectors(patchEnd, patchStart);
+            const voxelsCountPerPatch = patchSize.x * patchSize.y * patchSize.z;
+            if (voxelsCountPerPatch <= 0) {
+                return [];
+            }
+
+            const localMapCache = await this.buildLocalMapCache(patchStart, patchEnd);
+            if (localMapCache.isEmpty) {
+                return [];
+            }
+
+            const patchComputerGpu = await this.getPatchComputerGpu();
+            const buffers = await patchComputerGpu.computeBuffers(localMapCache);
+            return this.assembleGeometryAndMaterials(buffers);
+        });
+    }
+}
+
+export { PatchFactoryGpuSequential };

--- a/src/lib/terrain/patch/patch-factory/merged/gpu/patch-factory-gpu-sequential.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/gpu/patch-factory-gpu-sequential.ts
@@ -26,8 +26,8 @@ class PatchFactoryGpuSequential extends PatchFactoryGpu {
             }
 
             const patchComputerGpu = await this.getPatchComputerGpu();
-            const buffers = await patchComputerGpu.computeBuffers(localMapCache);
-            return this.assembleGeometryAndMaterials(buffers);
+            const buffer = await patchComputerGpu.computeBuffer(localMapCache);
+            return this.assembleGeometryAndMaterials(buffer);
         });
     }
 }

--- a/src/lib/terrain/patch/patch-factory/merged/gpu/patch-factory-gpu.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/gpu/patch-factory-gpu.ts
@@ -13,7 +13,11 @@ abstract class PatchFactoryGpu extends PatchFactory {
         }
         super(map, computingMode);
         const localCacheSize = this.maxPatchSize.clone().addScalar(2);
-        this.patchComputerGpuPromise = PatchComputerGpu.create(localCacheSize, PatchFactory.vertexData1Encoder, PatchFactory.vertexData2Encoder);
+        this.patchComputerGpuPromise = PatchComputerGpu.create(
+            localCacheSize,
+            PatchFactory.vertexData1Encoder,
+            PatchFactory.vertexData2Encoder
+        );
     }
 
     protected override async disposeInternal(): Promise<void> {

--- a/src/lib/terrain/patch/patch-factory/merged/gpu/patch-factory-gpu.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/gpu/patch-factory-gpu.ts
@@ -1,0 +1,37 @@
+import { type IVoxelMap } from '../../../../i-voxel-map';
+import { EPatchComputingMode } from '../../patch-factory-base';
+import { PatchFactory } from '../patch-factory';
+
+import { PatchComputerGpu } from './patch-computer-gpu';
+
+abstract class PatchFactoryGpu extends PatchFactory {
+    private readonly patchComputerGpuPromise: Promise<PatchComputerGpu> | null = null;
+
+    protected constructor(map: IVoxelMap, computingMode: EPatchComputingMode) {
+        if (computingMode !== EPatchComputingMode.GPU_SEQUENTIAL && computingMode !== EPatchComputingMode.GPU_OPTIMIZED) {
+            throw new Error(`Unsupported computing mode "${computingMode}".`);
+        }
+        super(map, computingMode);
+        const localCacheSize = this.maxPatchSize.clone().addScalar(2);
+        this.patchComputerGpuPromise = PatchComputerGpu.create(localCacheSize, PatchFactory.vertexData1Encoder, PatchFactory.vertexData2Encoder);
+    }
+
+    protected override async disposeInternal(): Promise<void> {
+        await super.disposeInternal();
+
+        const computer = await this.patchComputerGpuPromise;
+        if (computer) {
+            computer.dispose();
+        }
+    }
+
+    protected async getPatchComputerGpu(): Promise<PatchComputerGpu> {
+        const patchComputerGpu = await this.patchComputerGpuPromise;
+        if (!patchComputerGpu) {
+            throw new Error('Could not get WebGPU patch computer');
+        }
+        return patchComputerGpu;
+    }
+}
+
+export { PatchFactoryGpu };

--- a/src/lib/terrain/patch/patch-factory/merged/patch-factory.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/patch-factory.ts
@@ -78,10 +78,11 @@ void main() {`,
         ${PatchFactory.vertexData1Encoder.voxelZ.glslDecode(PatchFactory.data1AttributeName)}
     );
 
-    const uvec3 localVertexPositions[] = uvec3[](
-        ${Cube.faces[faceType].vertices.map(vertex => `uvec3(${vertex.vertex.x}, ${vertex.vertex.y}, ${vertex.vertex.z})`).join(',\n\t\t')}
+    uvec3 localVertexPosition = uvec3(
+        ${PatchFactory.vertexData1Encoder.localX.glslDecode(PatchFactory.data1AttributeName)},
+        ${PatchFactory.vertexData1Encoder.localY.glslDecode(PatchFactory.data1AttributeName)},
+        ${PatchFactory.vertexData1Encoder.localZ.glslDecode(PatchFactory.data1AttributeName)}
     );
-    uvec3 localVertexPosition = localVertexPositions[vertexId];
     vec3 modelPosition = vec3(modelVoxelPosition + localVertexPosition);
     vec3 transformed = modelPosition;
     
@@ -199,7 +200,7 @@ void main() {
         return material;
     }
 
-    private buildShadowMaterial(faceType: Cube.FaceType): THREE.Material {
+    private buildShadowMaterial(): THREE.Material {
         // Custom shadow material using RGBA depth packing.
         // A custom material for shadows is needed here, because the geometry is created inside the vertex shader,
         // so the builtin threejs shadow material will not work.
@@ -225,12 +226,11 @@ void main() {
                 ${PatchFactory.vertexData1Encoder.voxelZ.glslDecode(PatchFactory.data1AttributeName)}
             );
 
-            const uvec3 localVertexPositions[] = uvec3[](
-                ${Cube.faces[faceType].vertices
-                    .map(vertex => `uvec3(${vertex.vertex.x}, ${vertex.vertex.y}, ${vertex.vertex.z})`)
-                    .join(',\n')}
+            uvec3 localVertexPosition = uvec3(
+                ${PatchFactory.vertexData1Encoder.localX.glslDecode(PatchFactory.data1AttributeName)},
+                ${PatchFactory.vertexData1Encoder.localY.glslDecode(PatchFactory.data1AttributeName)},
+                ${PatchFactory.vertexData1Encoder.localZ.glslDecode(PatchFactory.data1AttributeName)}
             );
-            uvec3 localVertexPosition = localVertexPositions[vertexId];
             vec3 modelPosition = vec3(modelVoxelPosition + localVertexPosition);
             gl_Position = projectionMatrix * modelViewMatrix * vec4(modelPosition, 1.0);
 
@@ -256,7 +256,7 @@ void main() {
 
     private buildPatchMaterial(faceType: Cube.FaceType): PatchMaterials {
         const material = this.buildThreeJsPatchMaterial(faceType);
-        const shadowMaterial = this.buildShadowMaterial(faceType);
+        const shadowMaterial = this.buildShadowMaterial();
         return { material, shadowMaterial };
     }
 
@@ -300,7 +300,7 @@ void main() {
         const materials = this.materialsTemplates[faceType];
         const geometry = new THREE.BufferGeometry();
         const interleavedBuffer = new THREE.InterleavedBuffer(buffer, 2);
-        
+
         const data1Attribute = new THREE.InterleavedBufferAttribute(interleavedBuffer, 1, 0);
         const data2Attribute = new THREE.InterleavedBufferAttribute(interleavedBuffer, 1, 1);
 

--- a/src/lib/terrain/patch/patch-factory/merged/patch-factory.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/patch-factory.ts
@@ -97,14 +97,14 @@ void main() {`,
     vEdgeRoundness = edgeRoundness[edgeRoundnessId];
 
     vAo = float(${PatchFactory.vertexData1Encoder.ao.glslDecode(
-                    PatchFactory.data1AttributeName
-                )}) / ${PatchFactory.vertexData1Encoder.ao.maxValue.toFixed(1)};
+        PatchFactory.data1AttributeName
+    )}) / ${PatchFactory.vertexData1Encoder.ao.maxValue.toFixed(1)};
 
     vData2 = ${PatchFactory.data2AttributeName};
         `,
                 '#include <beginnormal_vertex>': `
     const vec3 faceNormalById[] = vec3[](
-        ${Cube.facesById.map(face => `vec3(${face.normal.vec.x}, ${face.normal.vec.y}, ${face.normal.vec.z})`).join(",\n")}
+        ${Cube.facesById.map(face => `vec3(${face.normal.vec.x}, ${face.normal.vec.y}, ${face.normal.vec.z})`).join(',\n')}
     );
     uint faceId = ${PatchFactory.vertexData1Encoder.faceId.glslDecode(PatchFactory.data1AttributeName)};
     vec3 objectNormal = faceNormalById[faceId];
@@ -131,10 +131,10 @@ in float vAo;
 
 vec3 computeModelNormal() {
     const vec3 modelNormalsById[] = vec3[](
-        ${Cube.normalsById.map(value => `vec3(${value.x}, ${value.y}, ${value.z})`).join(",\n")}
+        ${Cube.normalsById.map(value => `vec3(${value.x}, ${value.y}, ${value.z})`).join(',\n')}
     );
 
-    vec3 modelFaceNormal = modelNormalsById[${PatchFactory.vertexData2Encoder.normalId.glslDecode("vData2")}];
+    vec3 modelFaceNormal = modelNormalsById[${PatchFactory.vertexData2Encoder.normalId.glslDecode('vData2')}];
     if (uSmoothEdgeRadius <= 0.0) {
         return modelFaceNormal;
     }
@@ -157,7 +157,7 @@ vec3 computeModelNormal() {
         localNormal = normalize(vec3(distanceFromMargin, 1));
     }
 
-    vec3 uvRight = modelNormalsById[${PatchFactory.vertexData2Encoder.uvRightId.glslDecode("vData2")}];
+    vec3 uvRight = modelNormalsById[${PatchFactory.vertexData2Encoder.uvRightId.glslDecode('vData2')}];
     vec3 uvUp = cross(modelFaceNormal, uvRight);
 
     vec3 modelNormal = localNormal.x * uvRight + localNormal.y * uvUp + localNormal.z * modelFaceNormal;
@@ -285,7 +285,7 @@ void main() {
         geometry.setAttribute(PatchFactory.data2AttributeName, data2Attribute);
         geometry.setDrawRange(0, verticesCount);
 
-        return [{ id: "merged", materials: this.materialsTemplates, geometry }];
+        return [{ id: 'merged', materials: this.materialsTemplates, geometry }];
     }
 }
 

--- a/src/lib/terrain/patch/patch-factory/merged/patch-factory.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/patch-factory.ts
@@ -265,33 +265,12 @@ void main() {
         this.materialsTemplates.shadowMaterial.dispose();
     }
 
-    protected assembleGeometryAndMaterials(buffers: Record<Cube.FaceType, Uint32Array>): GeometryAndMaterial[] {
-        const processedBuffers = [
-            this.assembleGeometryAndMaterial('up', buffers),
-            this.assembleGeometryAndMaterial('down', buffers),
-            this.assembleGeometryAndMaterial('left', buffers),
-            this.assembleGeometryAndMaterial('right', buffers),
-            this.assembleGeometryAndMaterial('front', buffers),
-            this.assembleGeometryAndMaterial('back', buffers),
-        ];
-
-        const result: GeometryAndMaterial[] = [];
-        for (const processedBuffer of processedBuffers) {
-            if (processedBuffer) {
-                result.push(processedBuffer);
-            }
-        }
-        return result;
-    }
-
-    private assembleGeometryAndMaterial(faceType: Cube.FaceType, buffers: Record<Cube.FaceType, Uint32Array>): GeometryAndMaterial | null {
-        const buffer = buffers[faceType];
+    protected assembleGeometryAndMaterials(buffer: Uint32Array): GeometryAndMaterial[] {
         const verticesCount = buffer.length / 2;
         if (verticesCount === 0) {
-            return null;
+            return [];
         }
 
-        const materials = this.materialsTemplates;
         const geometry = new THREE.BufferGeometry();
         const interleavedBuffer = new THREE.InterleavedBuffer(buffer, 2);
 
@@ -306,8 +285,7 @@ void main() {
         geometry.setAttribute(PatchFactory.data2AttributeName, data2Attribute);
         geometry.setDrawRange(0, verticesCount);
 
-
-        return { id: faceType, materials, geometry };
+        return [{ id: "merged", materials: this.materialsTemplates, geometry }];
     }
 }
 

--- a/src/lib/terrain/patch/patch-factory/merged/patch-factory.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/patch-factory.ts
@@ -1,0 +1,321 @@
+import * as THREE from '../../../../three-usage';
+import { type IVoxelMap } from '../../../i-voxel-map';
+import { EDisplayMode, type PatchMaterial, type PatchMaterialUniforms, type PatchMaterials } from '../../material';
+import * as Cube from '../cube';
+import { EPatchComputingMode, type GeometryAndMaterial, PatchFactoryBase } from '../patch-factory-base';
+
+import { VertexData1Encoder } from './vertex-data1-encoder';
+import { VertexData2Encoder } from './vertex-data2-encoder';
+
+type PatchMaterialTemp = THREE.Material & {
+    readonly userData: {
+        uniforms: PatchMaterialUniforms;
+    };
+};
+
+abstract class PatchFactory extends PatchFactoryBase {
+    private static readonly data1AttributeName = 'aData';
+    private static readonly data2AttributeName = 'aData2';
+
+    protected static readonly vertexData1Encoder = new VertexData1Encoder();
+    protected static readonly vertexData2Encoder = new VertexData2Encoder();
+
+    public readonly maxPatchSize = new THREE.Vector3(
+        PatchFactory.vertexData1Encoder.voxelX.maxValue + 1,
+        PatchFactory.vertexData1Encoder.voxelY.maxValue + 1,
+        PatchFactory.vertexData1Encoder.voxelZ.maxValue + 1
+    );
+
+    private readonly materialsTemplates: Record<Cube.FaceType, PatchMaterials> = {
+        up: this.buildPatchMaterial('up'),
+        down: this.buildPatchMaterial('down'),
+        left: this.buildPatchMaterial('left'),
+        right: this.buildPatchMaterial('right'),
+        front: this.buildPatchMaterial('front'),
+        back: this.buildPatchMaterial('back'),
+    };
+
+    private buildThreeJsPatchMaterial(faceType: Cube.FaceType): PatchMaterial {
+        function applyReplacements(source: string, replacements: Record<string, string>): string {
+            let result = source;
+
+            for (const [source, replacement] of Object.entries(replacements)) {
+                result = result.replace(source, replacement);
+            }
+
+            return result;
+        }
+
+        const phongMaterial = new THREE.MeshPhongMaterial();
+        phongMaterial.shininess = 0;
+        const material = phongMaterial as unknown as PatchMaterialTemp;
+        material.userData.uniforms = this.uniformsTemplate;
+        material.customProgramCacheKey = () => `patch-factory-split_${faceType}`;
+        material.onBeforeCompile = parameters => {
+            parameters.uniforms = {
+                ...parameters.uniforms,
+                ...material.userData.uniforms,
+            };
+
+            parameters.vertexShader = applyReplacements(parameters.vertexShader, {
+                'void main() {': `
+in uint ${PatchFactory.data1AttributeName};
+in uint ${PatchFactory.data2AttributeName};
+
+out vec2 vUv;
+out vec2 vEdgeRoundness;
+flat out int vMaterial;
+flat out int vNoise;
+out float vAo;
+
+void main() {`,
+                '#include <begin_vertex>': `
+    const uint vertexIds[] = uint[](${Cube.faceIndices.map(indice => `${indice}u`).join(', ')});
+    uint vertexId = vertexIds[gl_VertexID % 6];
+
+    uvec3 modelVoxelPosition = uvec3(
+        ${PatchFactory.vertexData1Encoder.voxelX.glslDecode(PatchFactory.data1AttributeName)},
+        ${PatchFactory.vertexData1Encoder.voxelY.glslDecode(PatchFactory.data1AttributeName)},
+        ${PatchFactory.vertexData1Encoder.voxelZ.glslDecode(PatchFactory.data1AttributeName)}
+    );
+
+    const uvec3 localVertexPositions[] = uvec3[](
+        ${Cube.faces[faceType].vertices.map(vertex => `uvec3(${vertex.vertex.x}, ${vertex.vertex.y}, ${vertex.vertex.z})`).join(',\n\t\t')}
+    );
+    uvec3 localVertexPosition = localVertexPositions[vertexId];
+    vec3 modelPosition = vec3(modelVoxelPosition + localVertexPosition);
+    vec3 transformed = modelPosition;
+    
+    const vec2 uvs[] = vec2[](
+            vec2(0,0),
+            vec2(0,1),
+            vec2(1,0),
+            vec2(1,1)
+        );
+        vUv = uvs[vertexId];
+
+        const vec2 edgeRoundness[] = vec2[](
+            vec2(0,0),
+            vec2(1,0),
+            vec2(0,1),
+            vec2(1,1)
+        );
+        uint edgeRoundnessId = ${PatchFactory.vertexData1Encoder.edgeRoundness.glslDecode(PatchFactory.data1AttributeName)};
+        vEdgeRoundness = edgeRoundness[edgeRoundnessId];
+
+        vAo = float(${PatchFactory.vertexData1Encoder.ao.glslDecode(
+            PatchFactory.data1AttributeName
+        )}) / ${PatchFactory.vertexData1Encoder.ao.maxValue.toFixed(1)};
+
+        vMaterial = int(${PatchFactory.data2AttributeName} & 255u);
+        vNoise = int(modelVoxelPosition.x + modelVoxelPosition.y * 3u + modelVoxelPosition.z * 2u) % ${this.noiseTypes};
+        `,
+                '#include <beginnormal_vertex>': `
+    vec3 objectNormal = vec3(${Cube.faces[faceType].normal.x}, ${Cube.faces[faceType].normal.y}, ${Cube.faces[faceType].normal.z});
+`,
+            });
+
+            parameters.fragmentShader = applyReplacements(parameters.fragmentShader, {
+                'void main() {': `
+uniform sampler2D uTexture;
+uniform sampler2D uNoiseTexture;
+uniform float uNoiseStrength;
+uniform float uAoStrength;
+uniform float uAoSpread;
+uniform float uSmoothEdgeRadius;
+uniform uint uSmoothEdgeMethod;
+uniform uint uDisplayMode;
+
+uniform mat3 normalMatrix; // from three.js
+
+in vec2 vUv;
+in vec2 vEdgeRoundness;
+flat in int vMaterial;
+flat in int vNoise;
+in float vAo;
+
+vec3 computeModelNormal() {
+    const vec3 worldFaceNormal = vec3(${Cube.faces[faceType].normal.x.toFixed(1)}, ${Cube.faces[faceType].normal.y.toFixed(
+        1
+    )}, ${Cube.faces[faceType].normal.z.toFixed(1)});
+    if (uSmoothEdgeRadius <= 0.0) {
+        return worldFaceNormal;
+    }
+
+    vec3 localNormal;
+
+    vec2 edgeRoundness = step(${PatchFactoryBase.maxSmoothEdgeRadius.toFixed(2)}, vEdgeRoundness);
+    if (uSmoothEdgeMethod == 0u) {
+        vec2 margin = mix(vec2(0), vec2(uSmoothEdgeRadius), edgeRoundness);
+        vec3 roundnessCenter = vec3(clamp(vUv, margin, 1.0 - margin), -uSmoothEdgeRadius);
+        localNormal = normalize(vec3(vUv, 0) - roundnessCenter);
+    } else if (uSmoothEdgeMethod == 1u) {
+        vec2 symetricUv = clamp(vUv - 0.5, -0.5,  0.5);
+        vec2 distanceFromMargin = edgeRoundness * sign(symetricUv) * max(abs(symetricUv) - (0.5 - uSmoothEdgeRadius), 0.0) / uSmoothEdgeRadius;
+        localNormal = normalize(vec3(distanceFromMargin, 1));
+    } else if (uSmoothEdgeMethod == 2u) {
+        vec2 symetricUv = clamp(vUv - 0.5, -0.5,  0.5);
+        vec2 distanceFromMargin = edgeRoundness * sign(symetricUv) * max(abs(symetricUv) - (0.5 - uSmoothEdgeRadius), 0.0) / uSmoothEdgeRadius;
+        distanceFromMargin = sign(distanceFromMargin) * distanceFromMargin * distanceFromMargin;
+        localNormal = normalize(vec3(distanceFromMargin, 1));
+    }
+
+    const vec3 uvUp = vec3(${Cube.faces[faceType].uvUp.x.toFixed(1)}, ${Cube.faces[faceType].uvUp.y.toFixed(1)}, ${Cube.faces[
+        faceType
+    ].uvUp.z.toFixed(1)});
+    const vec3 uvRight = vec3(${Cube.faces[faceType].uvRight.x.toFixed(1)}, ${Cube.faces[faceType].uvRight.y.toFixed(1)}, ${Cube.faces[
+        faceType
+    ].uvRight.z.toFixed(1)});
+    vec3 modelNormal = localNormal.x * uvRight + localNormal.y * uvUp + localNormal.z * worldFaceNormal;
+    return normalMatrix * modelNormal;
+}
+
+float computeNoise() {
+    ivec2 texelCoords = clamp(ivec2(vUv * ${this.noiseResolution.toFixed(1)}), ivec2(0), ivec2(${this.noiseResolution - 1}));
+    texelCoords.x += vNoise * ${this.noiseResolution};
+    float noise = texelFetch(uNoiseTexture, texelCoords, 0).r - 0.5;
+    return uNoiseStrength * noise;
+}
+
+void main() {
+    vec3 modelFaceNormal = computeModelNormal();
+`,
+                '#include <normal_fragment_begin>': `
+    vec3 normal = modelFaceNormal;`,
+                '#include <map_fragment>': `
+    diffuseColor.rgb = vec3(0.75);
+    if (uDisplayMode == ${EDisplayMode.TEXTURES}u) {
+        ivec2 texelCoords = ivec2(vMaterial, 0);
+        diffuseColor.rgb = texelFetch(uTexture, texelCoords, 0).rgb;
+    } else if (uDisplayMode == ${EDisplayMode.NORMALS}u) {
+        diffuseColor.rgb = 0.5 + 0.5 * modelFaceNormal;
+    }
+    diffuseColor.rgb += computeNoise();
+    
+    float ao = (1.0 - uAoStrength) + uAoStrength * (smoothstep(0.0, uAoSpread, 1.0 - vAo));
+    diffuseColor.rgb *= ao;
+    `,
+            });
+        };
+        return material;
+    }
+
+    private buildShadowMaterial(faceType: Cube.FaceType): THREE.Material {
+        // Custom shadow material using RGBA depth packing.
+        // A custom material for shadows is needed here, because the geometry is created inside the vertex shader,
+        // so the builtin threejs shadow material will not work.
+        // Written like:
+        // https://github.com/mrdoob/three.js/blob/2ff77e4b335e31c108aac839a07401664998c730/src/renderers/shaders/ShaderLib/depth.glsl.js#L47
+        return new THREE.ShaderMaterial({
+            glslVersion: '300 es',
+            vertexShader: `
+        in uint ${PatchFactory.data1AttributeName};
+
+        // This is used for computing an equivalent of gl_FragCoord.z that is as high precision as possible.
+        // Some platforms compute gl_FragCoord at a lower precision which makes the manually computed value better for
+        // depth-based postprocessing effects. Reproduced on iPad with A10 processor / iPadOS 13.3.1.
+        varying vec2 vHighPrecisionZW;
+
+        void main(void) {
+            const uint vertexIds[] = uint[](${Cube.faceIndices.map(indice => `${indice}u`).join(', ')});
+            uint vertexId = vertexIds[gl_VertexID % 6];
+
+            uvec3 modelVoxelPosition = uvec3(
+                ${PatchFactory.vertexData1Encoder.voxelX.glslDecode(PatchFactory.data1AttributeName)},
+                ${PatchFactory.vertexData1Encoder.voxelY.glslDecode(PatchFactory.data1AttributeName)},
+                ${PatchFactory.vertexData1Encoder.voxelZ.glslDecode(PatchFactory.data1AttributeName)}
+            );
+
+            const uvec3 localVertexPositions[] = uvec3[](
+                ${Cube.faces[faceType].vertices
+                    .map(vertex => `uvec3(${vertex.vertex.x}, ${vertex.vertex.y}, ${vertex.vertex.z})`)
+                    .join(',\n')}
+            );
+            uvec3 localVertexPosition = localVertexPositions[vertexId];
+            vec3 modelPosition = vec3(modelVoxelPosition + localVertexPosition);
+            gl_Position = projectionMatrix * modelViewMatrix * vec4(modelPosition, 1.0);
+
+            vHighPrecisionZW = gl_Position.zw;
+        }`,
+            fragmentShader: `precision highp float;
+
+        #include <packing>
+
+        in vec2 vHighPrecisionZW;
+
+        out vec4 fragColor;
+
+        void main(void) {
+            // Higher precision equivalent of gl_FragCoord.z. This assumes depthRange has been left to its default values.
+            float fragCoordZ = 0.5 * vHighPrecisionZW[0] / vHighPrecisionZW[1] + 0.5;
+
+            // RGBA depth packing 
+            fragColor = packDepthToRGBA( fragCoordZ );
+        }`,
+        });
+    }
+
+    private buildPatchMaterial(faceType: Cube.FaceType): PatchMaterials {
+        const material = this.buildThreeJsPatchMaterial(faceType);
+        const shadowMaterial = this.buildShadowMaterial(faceType);
+        return { material, shadowMaterial };
+    }
+
+    protected constructor(map: IVoxelMap, computingMode: EPatchComputingMode) {
+        super(map, PatchFactory.vertexData2Encoder.voxelMaterialId, computingMode);
+    }
+
+    protected async disposeInternal(): Promise<void> {
+        for (const material of Object.values(this.materialsTemplates)) {
+            material.material.dispose();
+            material.shadowMaterial.dispose();
+        }
+    }
+
+    protected assembleGeometryAndMaterials(buffers: Record<Cube.FaceType, Uint32Array>): GeometryAndMaterial[] {
+        const processedBuffers = [
+            this.assembleGeometryAndMaterial('up', buffers),
+            this.assembleGeometryAndMaterial('down', buffers),
+            this.assembleGeometryAndMaterial('left', buffers),
+            this.assembleGeometryAndMaterial('right', buffers),
+            this.assembleGeometryAndMaterial('front', buffers),
+            this.assembleGeometryAndMaterial('back', buffers),
+        ];
+
+        const result: GeometryAndMaterial[] = [];
+        for (const processedBuffer of processedBuffers) {
+            if (processedBuffer) {
+                result.push(processedBuffer);
+            }
+        }
+        return result;
+    }
+
+    private assembleGeometryAndMaterial(faceType: Cube.FaceType, buffers: Record<Cube.FaceType, Uint32Array>): GeometryAndMaterial | null {
+        const buffer = buffers[faceType];
+        const verticesCount = buffer.length / 2;
+        if (verticesCount === 0) {
+            return null;
+        }
+
+        const materials = this.materialsTemplates[faceType];
+        const geometry = new THREE.BufferGeometry();
+        const interleavedBuffer = new THREE.InterleavedBuffer(buffer, 2);
+        
+        const data1Attribute = new THREE.InterleavedBufferAttribute(interleavedBuffer, 1, 0);
+        const data2Attribute = new THREE.InterleavedBufferAttribute(interleavedBuffer, 1, 1);
+
+        // const faceTypeVerticesDataBuffer = new THREE.Uint32BufferAttribute(buffer, 1, false);
+        // faceTypeVerticesDataBuffer.onUpload(() => {
+        //     (faceTypeVerticesDataBuffer.array as THREE.TypedArray | null) = null;
+        // });
+        geometry.setAttribute(PatchFactory.data1AttributeName, data1Attribute);
+        geometry.setAttribute(PatchFactory.data2AttributeName, data2Attribute);
+        geometry.setDrawRange(0, verticesCount);
+
+
+        return { id: faceType, materials, geometry };
+    }
+}
+
+export { PatchFactory, type PatchMaterials };

--- a/src/lib/terrain/patch/patch-factory/merged/vertex-data1-encoder.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/vertex-data1-encoder.ts
@@ -1,35 +1,42 @@
 import { PackedUintFactory } from '../uint-packing';
+import * as THREE from "../../../../three-usage";
 
 class VertexData1Encoder {
     private readonly packedUintFactory = new PackedUintFactory(32);
     public readonly voxelX = this.packedUintFactory.encodePart(64);
     public readonly voxelY = this.packedUintFactory.encodePart(64);
     public readonly voxelZ = this.packedUintFactory.encodePart(64);
+    public readonly localX = this.packedUintFactory.encodePart(2);
+    public readonly localY = this.packedUintFactory.encodePart(2);
+    public readonly localZ = this.packedUintFactory.encodePart(2);
     public readonly ao = this.packedUintFactory.encodePart(4);
     public readonly edgeRoundness = this.packedUintFactory.encodePart(4);
 
     public encode(
-        posX: number,
-        posY: number,
-        posZ: number,
+        voxelPos: THREE.Vector3Like,
+        localPos: THREE.Vector3Like,
         ao: number,
         edgeRoundness: [boolean, boolean]
     ): number {
         return (
-            this.voxelX.encode(posX) +
-            this.voxelY.encode(posY) +
-            this.voxelZ.encode(posZ) +
+            this.voxelX.encode(voxelPos.x) +
+            this.voxelY.encode(voxelPos.y) +
+            this.voxelZ.encode(voxelPos.z) +
+            this.localX.encode(localPos.x) +
+            this.localY.encode(localPos.y) +
+            this.localZ.encode(localPos.z) +
             this.ao.encode(ao) +
             this.edgeRoundness.encode(+edgeRoundness[0] + (+edgeRoundness[1] << 1))
         );
     }
 
-    public wgslEncodeVoxelData(posXVarname: string, posYVarname: string, posZVarname: string): string {
-        return `(${this.voxelX.wgslEncode(posXVarname)} + ${this.voxelY.wgslEncode(posYVarname)} + ${this.voxelZ.wgslEncode(posZVarname)})`;
+    public wgslEncodeVoxelData(voxelPosVarname: string): string {
+        return `(${this.voxelX.wgslEncode(voxelPosVarname + ".x")} + ${this.voxelY.wgslEncode(voxelPosVarname + ".y")} + ${this.voxelZ.wgslEncode(voxelPosVarname + ".z")})`;
     }
 
-    public wgslEncodeVertexData(aoVarname: string, edgeRoundessX: string, edgeRoundnessY: string): string {
-        return `(${this.ao.wgslEncode(aoVarname)} + ${this.edgeRoundness.wgslEncode(`(${edgeRoundessX} + (${edgeRoundnessY} << 1u))`)})`;
+    public wgslEncodeVertexData(localPosVarname: string, aoVarname: string, edgeRoundessX: string, edgeRoundnessY: string): string {
+        return `(${this.localX.wgslEncode(localPosVarname + ".x")} + ${this.localY.wgslEncode(localPosVarname + ".y")} + ${this.localZ.wgslEncode(localPosVarname + ".z")} +
+            ${this.ao.wgslEncode(aoVarname)} + ${this.edgeRoundness.wgslEncode(`(${edgeRoundessX} + (${edgeRoundnessY} << 1u))`)})`;
     }
 }
 

--- a/src/lib/terrain/patch/patch-factory/merged/vertex-data1-encoder.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/vertex-data1-encoder.ts
@@ -1,5 +1,5 @@
 import { PackedUintFactory } from '../uint-packing';
-import * as THREE from "../../../../three-usage";
+import * as THREE from '../../../../three-usage';
 
 class VertexData1Encoder {
     private readonly packedUintFactory = new PackedUintFactory(32);
@@ -34,11 +34,11 @@ class VertexData1Encoder {
     }
 
     public wgslEncodeVoxelData(voxelPosVarname: string): string {
-        return `(${this.voxelX.wgslEncode(voxelPosVarname + ".x")} + ${this.voxelY.wgslEncode(voxelPosVarname + ".y")} + ${this.voxelZ.wgslEncode(voxelPosVarname + ".z")})`;
+        return `(${this.voxelX.wgslEncode(voxelPosVarname + '.x')} + ${this.voxelY.wgslEncode(voxelPosVarname + '.y')} + ${this.voxelZ.wgslEncode(voxelPosVarname + '.z')})`;
     }
 
     public wgslEncodeVertexData(localPosVarname: string, aoVarname: string, edgeRoundessX: string, edgeRoundnessY: string): string {
-        return `(${this.localX.wgslEncode(localPosVarname + ".x")} + ${this.localY.wgslEncode(localPosVarname + ".y")} + ${this.localZ.wgslEncode(localPosVarname + ".z")} +
+        return `(${this.localX.wgslEncode(localPosVarname + '.x')} + ${this.localY.wgslEncode(localPosVarname + '.y')} + ${this.localZ.wgslEncode(localPosVarname + '.z')} +
             ${this.ao.wgslEncode(aoVarname)} + ${this.edgeRoundness.wgslEncode(`(${edgeRoundessX} + (${edgeRoundnessY} << 1u))`)})`;
     }
 }

--- a/src/lib/terrain/patch/patch-factory/merged/vertex-data1-encoder.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/vertex-data1-encoder.ts
@@ -9,12 +9,14 @@ class VertexData1Encoder {
     public readonly localX = this.packedUintFactory.encodePart(2);
     public readonly localY = this.packedUintFactory.encodePart(2);
     public readonly localZ = this.packedUintFactory.encodePart(2);
+    public readonly faceId = this.packedUintFactory.encodePart(6);
     public readonly ao = this.packedUintFactory.encodePart(4);
     public readonly edgeRoundness = this.packedUintFactory.encodePart(4);
 
     public encode(
         voxelPos: THREE.Vector3Like,
         localPos: THREE.Vector3Like,
+        faceId: number,
         ao: number,
         edgeRoundness: [boolean, boolean]
     ): number {
@@ -25,6 +27,7 @@ class VertexData1Encoder {
             this.localX.encode(localPos.x) +
             this.localY.encode(localPos.y) +
             this.localZ.encode(localPos.z) +
+            this.faceId.encode(faceId) +
             this.ao.encode(ao) +
             this.edgeRoundness.encode(+edgeRoundness[0] + (+edgeRoundness[1] << 1))
         );

--- a/src/lib/terrain/patch/patch-factory/merged/vertex-data1-encoder.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/vertex-data1-encoder.ts
@@ -1,0 +1,36 @@
+import { PackedUintFactory } from '../uint-packing';
+
+class VertexData1Encoder {
+    private readonly packedUintFactory = new PackedUintFactory(32);
+    public readonly voxelX = this.packedUintFactory.encodePart(64);
+    public readonly voxelY = this.packedUintFactory.encodePart(64);
+    public readonly voxelZ = this.packedUintFactory.encodePart(64);
+    public readonly ao = this.packedUintFactory.encodePart(4);
+    public readonly edgeRoundness = this.packedUintFactory.encodePart(4);
+
+    public encode(
+        posX: number,
+        posY: number,
+        posZ: number,
+        ao: number,
+        edgeRoundness: [boolean, boolean]
+    ): number {
+        return (
+            this.voxelX.encode(posX) +
+            this.voxelY.encode(posY) +
+            this.voxelZ.encode(posZ) +
+            this.ao.encode(ao) +
+            this.edgeRoundness.encode(+edgeRoundness[0] + (+edgeRoundness[1] << 1))
+        );
+    }
+
+    public wgslEncodeVoxelData(posXVarname: string, posYVarname: string, posZVarname: string): string {
+        return `(${this.voxelX.wgslEncode(posXVarname)} + ${this.voxelY.wgslEncode(posYVarname)} + ${this.voxelZ.wgslEncode(posZVarname)})`;
+    }
+
+    public wgslEncodeVertexData(aoVarname: string, edgeRoundessX: string, edgeRoundnessY: string): string {
+        return `(${this.ao.wgslEncode(aoVarname)} + ${this.edgeRoundness.wgslEncode(`(${edgeRoundessX} + (${edgeRoundnessY} << 1u))`)})`;
+    }
+}
+
+export { VertexData1Encoder };

--- a/src/lib/terrain/patch/patch-factory/merged/vertex-data2-encoder.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/vertex-data2-encoder.ts
@@ -1,0 +1,20 @@
+import { PackedUintFactory } from '../uint-packing';
+
+class VertexData2Encoder {
+    private readonly packedUintFactory = new PackedUintFactory(32);
+    public readonly voxelMaterialId = this.packedUintFactory.encodePart(1 << 15);
+
+    public encode(
+        voxelMaterialId: number,
+    ): number {
+        return (
+            this.voxelMaterialId.encode(voxelMaterialId)
+        );
+    }
+
+    public wgslEncodeVoxelData(voxelMaterialIdVarname: string): string {
+        return `(${this.voxelMaterialId.wgslEncode(voxelMaterialIdVarname)})`;
+    }
+}
+
+export { VertexData2Encoder };

--- a/src/lib/terrain/patch/patch-factory/merged/vertex-data2-encoder.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/vertex-data2-encoder.ts
@@ -4,19 +4,26 @@ class VertexData2Encoder {
     private readonly packedUintFactory = new PackedUintFactory(32);
     public readonly voxelMaterialId = this.packedUintFactory.encodePart(1 << 15);
     public readonly faceNoiseId = this.packedUintFactory.encodePart(16);
+    public readonly normalId = this.packedUintFactory.encodePart(6);
+    public readonly uvRightId = this.packedUintFactory.encodePart(6);
 
     public encode(
         voxelMaterialId: number,
         faceNoiseId: number,
+        normalId: number,
+        uvRightId: number,
     ): number {
         return (
             this.voxelMaterialId.encode(voxelMaterialId) +
-            this.faceNoiseId.encode(faceNoiseId)
+            this.faceNoiseId.encode(faceNoiseId) +
+            this.normalId.encode(normalId) +
+            this.uvRightId.encode(uvRightId)
         );
     }
 
-    public wgslEncodeVoxelData(voxelMaterialIdVarname: string, faceNoiseIdVarname: string): string {
-        return `(${this.voxelMaterialId.wgslEncode(voxelMaterialIdVarname)} + ${this.faceNoiseId.wgslEncode(faceNoiseIdVarname)})`;
+    public wgslEncodeVoxelData(voxelMaterialIdVarname: string, faceNoiseIdVarname: string, normalIdVarname: string, uvRightIdVarname: string): string {
+        return `(${this.voxelMaterialId.wgslEncode(voxelMaterialIdVarname)} + ${this.faceNoiseId.wgslEncode(faceNoiseIdVarname)}
+        + ${this.normalId.wgslEncode(normalIdVarname)} + ${this.uvRightId.wgslEncode(uvRightIdVarname)})`;
     }
 }
 

--- a/src/lib/terrain/patch/patch-factory/merged/vertex-data2-encoder.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/vertex-data2-encoder.ts
@@ -7,12 +7,7 @@ class VertexData2Encoder {
     public readonly normalId = this.packedUintFactory.encodePart(6);
     public readonly uvRightId = this.packedUintFactory.encodePart(6);
 
-    public encode(
-        voxelMaterialId: number,
-        faceNoiseId: number,
-        normalId: number,
-        uvRightId: number,
-    ): number {
+    public encode(voxelMaterialId: number, faceNoiseId: number, normalId: number, uvRightId: number): number {
         return (
             this.voxelMaterialId.encode(voxelMaterialId) +
             this.faceNoiseId.encode(faceNoiseId) +
@@ -21,7 +16,12 @@ class VertexData2Encoder {
         );
     }
 
-    public wgslEncodeVoxelData(voxelMaterialIdVarname: string, faceNoiseIdVarname: string, normalIdVarname: string, uvRightIdVarname: string): string {
+    public wgslEncodeVoxelData(
+        voxelMaterialIdVarname: string,
+        faceNoiseIdVarname: string,
+        normalIdVarname: string,
+        uvRightIdVarname: string
+    ): string {
         return `(${this.voxelMaterialId.wgslEncode(voxelMaterialIdVarname)} + ${this.faceNoiseId.wgslEncode(faceNoiseIdVarname)}
         + ${this.normalId.wgslEncode(normalIdVarname)} + ${this.uvRightId.wgslEncode(uvRightIdVarname)})`;
     }

--- a/src/lib/terrain/patch/patch-factory/merged/vertex-data2-encoder.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/vertex-data2-encoder.ts
@@ -3,17 +3,20 @@ import { PackedUintFactory } from '../uint-packing';
 class VertexData2Encoder {
     private readonly packedUintFactory = new PackedUintFactory(32);
     public readonly voxelMaterialId = this.packedUintFactory.encodePart(1 << 15);
+    public readonly faceNoiseId = this.packedUintFactory.encodePart(16);
 
     public encode(
         voxelMaterialId: number,
+        faceNoiseId: number,
     ): number {
         return (
-            this.voxelMaterialId.encode(voxelMaterialId)
+            this.voxelMaterialId.encode(voxelMaterialId) +
+            this.faceNoiseId.encode(faceNoiseId)
         );
     }
 
-    public wgslEncodeVoxelData(voxelMaterialIdVarname: string): string {
-        return `(${this.voxelMaterialId.wgslEncode(voxelMaterialIdVarname)})`;
+    public wgslEncodeVoxelData(voxelMaterialIdVarname: string, faceNoiseIdVarname: string): string {
+        return `(${this.voxelMaterialId.wgslEncode(voxelMaterialIdVarname)} + ${this.faceNoiseId.wgslEncode(faceNoiseIdVarname)})`;
     }
 }
 

--- a/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
+++ b/src/lib/terrain/patch/patch-factory/patch-factory-base.ts
@@ -186,7 +186,7 @@ abstract class PatchFactoryBase {
                             const voxelMaterialId = cacheData - 1;
 
                             for (const face of Object.values(Cube.faces)) {
-                                if (localMapCache.neighbourExists(cacheIndex, face.normal)) {
+                                if (localMapCache.neighbourExists(cacheIndex, face.normal.vec)) {
                                     // this face will be hidden -> skip it
                                     continue;
                                 }

--- a/src/lib/terrain/patch/patch-factory/split/gpu/patch-computer-gpu.ts
+++ b/src/lib/terrain/patch/patch-factory/split/gpu/patch-computer-gpu.ts
@@ -110,7 +110,7 @@ class PatchComputerGpu {
                     ${Object.values(Cube.faces)
                         .map(
                             face => `
-                    if (!doesNeighbourExist(cacheIndex, vec3i(${face.normal.x}, ${face.normal.y}, ${face.normal.z}))) {
+                    if (!doesNeighbourExist(cacheIndex, vec3i(${face.normal.vec.x}, ${face.normal.vec.y}, ${face.normal.vec.z}))) {
                         let firstVertexIndex: u32 = atomicAdd(&${face.type}FaceVerticesData.verticesCount, 6u);
                         var ao: u32;
                         var edgeRoundnessX: bool;

--- a/src/lib/terrain/patch/patch-factory/split/patch-factory.ts
+++ b/src/lib/terrain/patch/patch-factory/split/patch-factory.ts
@@ -83,8 +83,8 @@ abstract class PatchFactory extends PatchFactoryBase {
             vEdgeRoundness = edgeRoundness[edgeRoundnessId];
 
             vAo = float(${PatchFactory.vertexDataEncoder.ao.glslDecode(
-                PatchFactory.dataAttributeName
-            )}) / ${PatchFactory.vertexDataEncoder.ao.maxValue.toFixed(1)};
+                        PatchFactory.dataAttributeName
+                    )}) / ${PatchFactory.vertexDataEncoder.ao.maxValue.toFixed(1)};
 
             vMaterial = int(${PatchFactory.vertexDataEncoder.voxelMaterialId.glslDecode(PatchFactory.dataAttributeName)});
             vNoise = int(modelVoxelPosition.x + modelVoxelPosition.y * 3u + modelVoxelPosition.z * 2u) % ${this.noiseTypes};
@@ -113,9 +113,10 @@ abstract class PatchFactory extends PatchFactoryBase {
         out vec4 fragColor;
 
         vec3 computeModelNormal() {
-            const vec3 worldFaceNormal = vec3(${Cube.faces[faceType].normal.x.toFixed(1)}, ${Cube.faces[faceType].normal.y.toFixed(
-                1
-            )}, ${Cube.faces[faceType].normal.z.toFixed(1)});
+            const vec3 worldFaceNormal = vec3(
+                ${Cube.faces[faceType].normal.vec.x},
+                ${Cube.faces[faceType].normal.vec.y},
+                ${Cube.faces[faceType].normal.vec.z});
             if (uSmoothEdgeRadius <= 0.0) {
                 return worldFaceNormal;
             }
@@ -138,12 +139,14 @@ abstract class PatchFactory extends PatchFactoryBase {
                 localNormal = normalize(vec3(distanceFromMargin, 1));
             }
 
-            const vec3 uvUp = vec3(${Cube.faces[faceType].uvUp.x.toFixed(1)}, ${Cube.faces[faceType].uvUp.y.toFixed(1)}, ${Cube.faces[
-                faceType
-            ].uvUp.z.toFixed(1)});
-            const vec3 uvRight = vec3(${Cube.faces[faceType].uvRight.x.toFixed(1)}, ${Cube.faces[faceType].uvRight.y.toFixed(
-                1
-            )}, ${Cube.faces[faceType].uvRight.z.toFixed(1)});
+            const vec3 uvUp = vec3(
+                ${Cube.faces[faceType].uvUp.vec.x},
+                ${Cube.faces[faceType].uvUp.vec.y},
+                ${Cube.faces[faceType].uvUp.vec.z});
+            const vec3 uvRight = vec3(
+                ${Cube.faces[faceType].uvRight.vec.x},
+                ${Cube.faces[faceType].uvRight.vec.y},
+                ${Cube.faces[faceType].uvRight.vec.z});
             return localNormal.x * uvRight + localNormal.y * uvUp + localNormal.z * worldFaceNormal;
         }
 
@@ -249,14 +252,18 @@ void main() {`,
         vEdgeRoundness = edgeRoundness[edgeRoundnessId];
 
         vAo = float(${PatchFactory.vertexDataEncoder.ao.glslDecode(
-            PatchFactory.dataAttributeName
-        )}) / ${PatchFactory.vertexDataEncoder.ao.maxValue.toFixed(1)};
+                    PatchFactory.dataAttributeName
+                )}) / ${PatchFactory.vertexDataEncoder.ao.maxValue.toFixed(1)};
 
         vMaterial = int(${PatchFactory.vertexDataEncoder.voxelMaterialId.glslDecode(PatchFactory.dataAttributeName)});
         vNoise = int(modelVoxelPosition.x + modelVoxelPosition.y * 3u + modelVoxelPosition.z * 2u) % ${this.noiseTypes};
         `,
                 '#include <beginnormal_vertex>': `
-    vec3 objectNormal = vec3(${Cube.faces[faceType].normal.x}, ${Cube.faces[faceType].normal.y}, ${Cube.faces[faceType].normal.z});
+    vec3 objectNormal = vec3(
+        ${Cube.faces[faceType].normal.vec.x},
+        ${Cube.faces[faceType].normal.vec.y},
+        ${Cube.faces[faceType].normal.vec.z}
+    );
 `,
             });
 
@@ -280,11 +287,13 @@ flat in int vNoise;
 in float vAo;
 
 vec3 computeModelNormal() {
-    const vec3 worldFaceNormal = vec3(${Cube.faces[faceType].normal.x.toFixed(1)}, ${Cube.faces[faceType].normal.y.toFixed(
-        1
-    )}, ${Cube.faces[faceType].normal.z.toFixed(1)});
+    const vec3 modelFaceNormal = vec3(
+        ${Cube.faces[faceType].normal.vec.x},
+        ${Cube.faces[faceType].normal.vec.y},
+        ${Cube.faces[faceType].normal.vec.z}
+    );
     if (uSmoothEdgeRadius <= 0.0) {
-        return worldFaceNormal;
+        return modelFaceNormal;
     }
 
     vec3 localNormal;
@@ -305,14 +314,18 @@ vec3 computeModelNormal() {
         localNormal = normalize(vec3(distanceFromMargin, 1));
     }
 
-    const vec3 uvUp = vec3(${Cube.faces[faceType].uvUp.x.toFixed(1)}, ${Cube.faces[faceType].uvUp.y.toFixed(1)}, ${Cube.faces[
-        faceType
-    ].uvUp.z.toFixed(1)});
-    const vec3 uvRight = vec3(${Cube.faces[faceType].uvRight.x.toFixed(1)}, ${Cube.faces[faceType].uvRight.y.toFixed(1)}, ${Cube.faces[
-        faceType
-    ].uvRight.z.toFixed(1)});
-    vec3 modelNormal = localNormal.x * uvRight + localNormal.y * uvUp + localNormal.z * worldFaceNormal;
-    return normalMatrix * modelNormal;
+    const vec3 uvUp = vec3(
+        ${Cube.faces[faceType].uvUp.vec.x},
+        ${Cube.faces[faceType].uvUp.vec.y},
+        ${Cube.faces[faceType].uvUp.vec.z}
+    );
+    const vec3 uvRight = vec3(
+        ${Cube.faces[faceType].uvRight.vec.x},
+        ${Cube.faces[faceType].uvRight.vec.y},
+        ${Cube.faces[faceType ].uvRight.vec.z}
+    );
+    vec3 modelNormal = localNormal.x * uvRight + localNormal.y * uvUp + localNormal.z * modelFaceNormal;
+    return modelNormal;
 }
 
 float computeNoise() {
@@ -326,7 +339,7 @@ void main() {
     vec3 modelFaceNormal = computeModelNormal();
 `,
                 '#include <normal_fragment_begin>': `
-    vec3 normal = modelFaceNormal;`,
+    vec3 normal = normalMatrix * modelFaceNormal;`,
                 '#include <map_fragment>': `
     diffuseColor.rgb = vec3(0.75);
     if (uDisplayMode == ${EDisplayMode.TEXTURES}u) {

--- a/src/lib/terrain/patch/patch-factory/split/patch-factory.ts
+++ b/src/lib/terrain/patch/patch-factory/split/patch-factory.ts
@@ -83,8 +83,8 @@ abstract class PatchFactory extends PatchFactoryBase {
             vEdgeRoundness = edgeRoundness[edgeRoundnessId];
 
             vAo = float(${PatchFactory.vertexDataEncoder.ao.glslDecode(
-                        PatchFactory.dataAttributeName
-                    )}) / ${PatchFactory.vertexDataEncoder.ao.maxValue.toFixed(1)};
+                PatchFactory.dataAttributeName
+            )}) / ${PatchFactory.vertexDataEncoder.ao.maxValue.toFixed(1)};
 
             vMaterial = int(${PatchFactory.vertexDataEncoder.voxelMaterialId.glslDecode(PatchFactory.dataAttributeName)});
             vNoise = int(modelVoxelPosition.x + modelVoxelPosition.y * 3u + modelVoxelPosition.z * 2u) % ${this.noiseTypes};
@@ -252,8 +252,8 @@ void main() {`,
         vEdgeRoundness = edgeRoundness[edgeRoundnessId];
 
         vAo = float(${PatchFactory.vertexDataEncoder.ao.glslDecode(
-                    PatchFactory.dataAttributeName
-                )}) / ${PatchFactory.vertexDataEncoder.ao.maxValue.toFixed(1)};
+            PatchFactory.dataAttributeName
+        )}) / ${PatchFactory.vertexDataEncoder.ao.maxValue.toFixed(1)};
 
         vMaterial = int(${PatchFactory.vertexDataEncoder.voxelMaterialId.glslDecode(PatchFactory.dataAttributeName)});
         vNoise = int(modelVoxelPosition.x + modelVoxelPosition.y * 3u + modelVoxelPosition.z * 2u) % ${this.noiseTypes};
@@ -322,7 +322,7 @@ vec3 computeModelNormal() {
     const vec3 uvRight = vec3(
         ${Cube.faces[faceType].uvRight.vec.x},
         ${Cube.faces[faceType].uvRight.vec.y},
-        ${Cube.faces[faceType ].uvRight.vec.z}
+        ${Cube.faces[faceType].uvRight.vec.z}
     );
     vec3 modelNormal = localNormal.x * uvRight + localNormal.y * uvUp + localNormal.z * modelFaceNormal;
     return modelNormal;

--- a/src/lib/terrain/terrain.ts
+++ b/src/lib/terrain/terrain.ts
@@ -6,9 +6,9 @@ import { HeightmapViewer } from './heightmap/heightmap-viewer';
 import { type IVoxelMap } from './i-voxel-map';
 import { EDisplayMode } from './patch/patch';
 import { EPatchComputingMode, PatchFactoryBase } from './patch/patch-factory/patch-factory-base';
-import { PatchFactoryCpu } from './patch/patch-factory/split/cpu/patch-factory-cpu';
-import { PatchFactoryGpuOptimized } from './patch/patch-factory/split/gpu/patch-factory-gpu-optimized';
-import { PatchFactoryGpuSequential } from './patch/patch-factory/split/gpu/patch-factory-gpu-sequential';
+import { PatchFactoryCpu } from './patch/patch-factory/merged/cpu/patch-factory-cpu';
+import { PatchFactoryGpuOptimized } from './patch/patch-factory/merged/gpu/patch-factory-gpu-optimized';
+import { PatchFactoryGpuSequential } from './patch/patch-factory/merged/gpu/patch-factory-gpu-sequential';
 import { PatchId } from './patch/patch-id';
 
 type TerrainOptions = {

--- a/src/lib/three-usage.ts
+++ b/src/lib/three-usage.ts
@@ -19,4 +19,6 @@ export {
     type TypedArray,
     type Vector2Like,
     type Vector3Like,
+    InterleavedBuffer,
+    InterleavedBufferAttribute,
 } from 'three';


### PR DESCRIPTION
This PR changes the rendering engine. Compared to the previous version:
- each Patch is now made of a single Mesh (compared to 6 before). This reduces the number of draw calls by 6 and greatly improves performance.
- bumped the max number of voxel materials to 32768
- the downside is that each Patch now takes twice as much GPU memory, but it remains low (< 1 Mo per 64x64 patch)