### PR TITLE
Feat/simplify three usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "@aresrpg/aresrpg-engine",
       "version": "1.6.1",
-      "dependencies": {
-        "three": "^0.163.0"
-      },
       "devDependencies": {
         "@types/three": "^0.163.0",
         "@typescript-eslint/eslint-plugin": "^7.5.0",
@@ -26,10 +23,14 @@
         "prettier": "^3.2.5",
         "shx": "^0.3.4",
         "simplex-noise": "^4.0.1",
+        "three": "^0.163.0",
         "ts-loader": "^9.5.1",
         "typescript": "^5.4.4",
         "webpack": "^5.91.0",
         "webpack-cli": "^5.1.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.163.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4758,7 +4759,8 @@
     "node_modules/three": {
       "version": "0.163.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.163.0.tgz",
-      "integrity": "sha512-HlMgCb2TF/dTLRtknBnjUTsR8FsDqBY43itYop2+Zg822I+Kd0Ua2vs8CvfBVefXkBdNDrLMoRTGCIIpfCuDew=="
+      "integrity": "sha512-HlMgCb2TF/dTLRtknBnjUTsR8FsDqBY43itYop2+Zg822I+Kd0Ua2vs8CvfBVefXkBdNDrLMoRTGCIIpfCuDew==",
+      "dev": true
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "three": "^0.163.0"
+  "peerDependencies": {
+    "three": ">=0.163.0"
   },
   "devDependencies": {
     "@types/three": "^0.163.0",
@@ -37,6 +37,7 @@
     "prettier": "^3.2.5",
     "shx": "^0.3.4",
     "simplex-noise": "^4.0.1",
+    "three": "^0.163.0",
     "ts-loader": "^9.5.1",
     "typescript": "^5.4.4",
     "webpack": "^5.91.0",

--- a/src/lib/terrain/patch/patch-factory/merged/gpu/patch-computer-gpu.ts
+++ b/src/lib/terrain/patch/patch-factory/merged/gpu/patch-computer-gpu.ts
@@ -1,7 +1,6 @@
 /// <reference types="@webgpu/types" />
 
-import * as THREE from 'three';
-
+import * as THREE from '../../../../../three-usage';
 import { logger } from '../../../../../helpers/logger';
 import { getGpuDevice } from '../../../../../helpers/webgpu/webgpu-device';
 import * as Cube from '../../cube';

--- a/src/lib/terrain/patch/patch-factory/split/gpu/patch-computer-gpu.ts
+++ b/src/lib/terrain/patch/patch-factory/split/gpu/patch-computer-gpu.ts
@@ -1,7 +1,6 @@
 /// <reference types="@webgpu/types" />
 
-import * as THREE from 'three';
-
+import * as THREE from '../../../../../three-usage';
 import { logger } from '../../../../../helpers/logger';
 import { getGpuDevice } from '../../../../../helpers/webgpu/webgpu-device';
 import * as Cube from '../../cube';


### PR DESCRIPTION
This PR:
- fixes an issue where the `aresrpg-engine` sometimes imported `three` directly instead of using the centralized `three-usage.ts`
- tries to fix a bug where at the start up of the `aresrpg-dapp`, we see 2 warnings
![image](https://github.com/aresrpg/aresrpg-engine/assets/22922087/076886ae-03f6-4248-a8e0-b50702e5a091)
These warnings mean that `aresrpg-world`, `aresrpg-dapp` and `aresrpg-engine` had different THREE versions.
My understanding is that it happens because `aresrpg-engine` wants a THREE v0.163.0 whereas `aresrpg-dapp` wants a THREE v0.164.1, so NPM installs both versions and both are bundled in the final product. To fix this, we could always synchronize versions in the 3 packages, but it is not very easy to do. I hope passing `three` as a `peerDependecy` instead of a `dependency` will make npm understand that `aresrpg-engine` can use the same version as `aresrpg-dapp`.
Importing multiple THREE versions is bad because:
  - it might lead to bugs
  - it slows down the start up of `aresrpg-dapp`, since a minified THREE is abound 600KB of minified javascript, so loading 3 different versions takes network and CPU time uselessly

