### PR TITLE
fix/lod holes

### DIFF
--- a/src/lib/terrain/terrain-viewer.ts
+++ b/src/lib/terrain/terrain-viewer.ts
@@ -41,6 +41,10 @@ class TerrainViewer {
 
         this.heightmapViewer = new HeightmapViewer(map, voxelmapViewer.chunkSize.xz);
         this.container.add(this.heightmapViewer.container);
+
+        this.voxelmapViewer.onChange.push(() => {
+            this.heightmapViewerNeedsUpdate = true;
+        });
     }
 
     /**

--- a/src/lib/terrain/voxelmap/viewer/autonomous/voxelmap-viewer-autonomous.ts
+++ b/src/lib/terrain/voxelmap/viewer/autonomous/voxelmap-viewer-autonomous.ts
@@ -109,10 +109,10 @@ class VoxelmapViewerAutonomous extends VoxelmapViewerBase {
             patchStart.multiplyVectors(requestedPatch.id, this.patchSize);
             const patch = this.getPatch(patchStart);
             patch.visible = true;
-            return patch.ready();
+            const patchReadyPromise = patch.ready();
+            patchReadyPromise.then(() => this.notifyChange());
+            return patchReadyPromise;
         });
-
-        // this.heightmapViewerNeedsUpdate = true;
 
         await Promise.all(promises);
     }
@@ -124,6 +124,7 @@ class VoxelmapViewerAutonomous extends VoxelmapViewerBase {
     public clear(): void {
         this.patchesStore.clear();
         this.container.clear();
+        this.notifyChange();
     }
 
     /**
@@ -183,6 +184,8 @@ class VoxelmapViewerAutonomous extends VoxelmapViewerBase {
             }
             this.disposePatch(nextPatchToDelete.id.asString);
         }
+
+        this.notifyChange();
     }
 
     private disposePatch(patchId: string): void {

--- a/src/lib/terrain/voxelmap/viewer/simple/voxelmap-viewer.ts
+++ b/src/lib/terrain/voxelmap/viewer/simple/voxelmap-viewer.ts
@@ -125,6 +125,7 @@ class VoxelmapViewer extends VoxelmapViewerBase {
                 const voxelsRenderable = await storedPatch.computationTask.start();
                 if (voxelsRenderable && storedPatch.isVisible) {
                     this.container.add(voxelsRenderable.container);
+                    this.notifyChange();
                 }
 
                 storedPatch.dispose = () => {
@@ -132,6 +133,7 @@ class VoxelmapViewer extends VoxelmapViewerBase {
                         const container = voxelsRenderable.container;
                         if (container.parent) {
                             container.parent.remove(container);
+                            this.notifyChange();
                         }
                         voxelsRenderable.dispose();
                     }
@@ -189,6 +191,8 @@ class VoxelmapViewer extends VoxelmapViewerBase {
                 });
             }
         }
+
+        this.notifyChange();
     }
 
     public override dispose(): void {

--- a/src/lib/terrain/voxelmap/viewer/voxelmap-viewer-base.ts
+++ b/src/lib/terrain/voxelmap/viewer/voxelmap-viewer-base.ts
@@ -48,6 +48,8 @@ abstract class VoxelmapViewerBase {
     public readonly chunkSize: VoxelsChunkSize;
     public readonly patchSize: THREE.Vector3Like;
 
+    public readonly onChange: VoidFunction[] = [];
+
     private maxPatchesInCache = 200;
     private garbageCollectionHandle: number | null;
 
@@ -150,6 +152,12 @@ abstract class VoxelmapViewerBase {
         }
 
         return result;
+    }
+
+    protected notifyChange(): void {
+        for (const callback of this.onChange) {
+            callback();
+        }
     }
 
     protected dispose(): void {


### PR DESCRIPTION
Fixes a bug where the lod was sometimes not updated correctly
If TerrainViewer.setLod was not called regularly, the LOD was not removed where the voxel patches were displayed.