### PR TITLE
Feat/greedy meshing

### DIFF
--- a/src/lib/terrain/voxelmap/patch/patch-factory/merged/patch-factory-cpu-worker.ts
+++ b/src/lib/terrain/voxelmap/patch/patch-factory/merged/patch-factory-cpu-worker.ts
@@ -6,26 +6,30 @@ import { VoxelsRenderableFactoryCpuWorker } from '../../../voxelsRenderable/voxe
 import { type CheckerboardType } from '../../../voxelsRenderable/voxelsRenderableFactory/voxels-renderable-factory-base';
 import { PatchFactoryBase } from '../patch-factory-base';
 
+type Parameters = {
+    readonly voxelMaterialsList: ReadonlyArray<IVoxelMaterial>;
+    readonly patchSize: VoxelsChunkSize;
+    readonly workersPoolSize: number;
+    readonly checkerboardType?: CheckerboardType;
+    readonly greedyMeshing?: boolean;
+};
+
 class PatchFactoryCpuWorker extends PatchFactoryBase {
     public readonly maxPatchesComputedInParallel: number;
     private readonly throttler: PromisesQueue;
 
-    public constructor(
-        voxelMaterialsList: ReadonlyArray<IVoxelMaterial>,
-        patchSize: VoxelsChunkSize,
-        workersPoolSize: number,
-        checkerboardType?: CheckerboardType
-    ) {
+    public constructor(params: Parameters) {
         const voxelsRenderableFactory = new VoxelsRenderableFactoryCpuWorker({
-            voxelMaterialsList,
-            maxVoxelsChunkSize: patchSize,
-            workersPoolSize,
-            checkerboardType,
+            voxelMaterialsList: params.voxelMaterialsList,
+            maxVoxelsChunkSize: params.patchSize,
+            workersPoolSize: params.workersPoolSize,
+            checkerboardType: params.checkerboardType,
+            greedyMeshing: params.greedyMeshing,
         });
         super(voxelsRenderableFactory);
 
         this.throttler = new PromisesQueue(voxelsRenderableFactory.workersPoolSize);
-        this.maxPatchesComputedInParallel = workersPoolSize;
+        this.maxPatchesComputedInParallel = params.workersPoolSize;
     }
 
     protected override queryMapAndBuildVoxelsRenderable(

--- a/src/lib/terrain/voxelmap/patch/patch-factory/merged/patch-factory-cpu.ts
+++ b/src/lib/terrain/voxelmap/patch/patch-factory/merged/patch-factory-cpu.ts
@@ -6,14 +6,22 @@ import { VoxelsRenderableFactoryCpu } from '../../../voxelsRenderable/voxelsRend
 import { type CheckerboardType } from '../../../voxelsRenderable/voxelsRenderableFactory/voxels-renderable-factory-base';
 import { PatchFactoryBase } from '../patch-factory-base';
 
+type Parameters = {
+    readonly voxelMaterialsList: ReadonlyArray<IVoxelMaterial>;
+    readonly patchSize: VoxelsChunkSize;
+    readonly checkerboardType?: CheckerboardType;
+    readonly greedyMeshing?: boolean;
+};
+
 class PatchFactoryCpu extends PatchFactoryBase {
     private readonly throttler = new PromisesQueue(1);
 
-    public constructor(voxelMaterialsList: ReadonlyArray<IVoxelMaterial>, patchSize: VoxelsChunkSize, checkerboardType?: CheckerboardType) {
+    public constructor(params: Parameters) {
         const voxelsRenderableFactory = new VoxelsRenderableFactoryCpu({
-            voxelMaterialsList,
-            maxVoxelsChunkSize: patchSize,
-            checkerboardType,
+            voxelMaterialsList: params.voxelMaterialsList,
+            maxVoxelsChunkSize: params.patchSize,
+            checkerboardType: params.checkerboardType,
+            greedyMeshing: params.greedyMeshing,
         });
         super(voxelsRenderableFactory);
     }

--- a/src/lib/terrain/voxelmap/viewer/autonomous/voxelmap-viewer-autonomous.ts
+++ b/src/lib/terrain/voxelmap/viewer/autonomous/voxelmap-viewer-autonomous.ts
@@ -50,7 +50,10 @@ class VoxelmapViewerAutonomous extends VoxelmapViewerBase {
 
         let patchFactory: PatchFactoryBase;
         if (computingMode === EPatchComputingMode.CPU_CACHED) {
-            patchFactory = new PatchFactoryCpu(map.voxelMaterialsList, voxelsChunksSize);
+            patchFactory = new PatchFactoryCpu({
+                voxelMaterialsList: map.voxelMaterialsList,
+                patchSize: voxelsChunksSize,
+            });
         } else if (computingMode === EPatchComputingMode.GPU_SEQUENTIAL) {
             patchFactory = new PatchFactoryGpuSequential(map.voxelMaterialsList, voxelsChunksSize);
         } else if (computingMode === EPatchComputingMode.GPU_OPTIMIZED) {

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/cpu/voxels-renderable-factory-cpu-worker.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/cpu/voxels-renderable-factory-cpu-worker.ts
@@ -10,6 +10,7 @@ type Parameters = {
     readonly maxVoxelsChunkSize: VoxelsChunkSize;
     readonly workersPoolSize: number;
     readonly checkerboardType?: CheckerboardType | undefined;
+    readonly greedyMeshing?: boolean | undefined;
 };
 
 class VoxelsRenderableFactoryCpuWorker extends VoxelsRenderableFactoryCpu {
@@ -21,11 +22,7 @@ class VoxelsRenderableFactoryCpuWorker extends VoxelsRenderableFactoryCpu {
     private workersPool: DedicatedWorkersPool | null = null;
 
     public constructor(params: Parameters) {
-        super({
-            voxelMaterialsList: params.voxelMaterialsList,
-            maxVoxelsChunkSize: params.maxVoxelsChunkSize,
-            checkerboardType: params.checkerboardType,
-        });
+        super(params);
 
         this.workersPoolSize = params.workersPoolSize;
     }

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/cpu/voxels-renderable-factory-cpu.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/cpu/voxels-renderable-factory-cpu.ts
@@ -73,8 +73,11 @@ class VoxelsRenderableFactoryCpu extends VoxelsRenderableFactory {
             const registerFace = (faceData: FaceData, checkerboardCellId: CheckerboardCellId) => {
                 faceData.verticesData.forEach((faceVertexData: VertexData, faceVertexIndex: number) => {
                     verticesData1[faceVertexIndex] = this.vertexData1Encoder.encode(
-                        faceData.voxelLocalPosition,
-                        faceVertexData.localPosition,
+                        {
+                            x: faceData.voxelLocalPosition.x + faceVertexData.localPosition.x,
+                            y: faceData.voxelLocalPosition.y + faceVertexData.localPosition.y,
+                            z: faceData.voxelLocalPosition.z + faceVertexData.localPosition.z,
+                        },
                         faceData.faceId,
                         faceVertexData.ao,
                         [faceVertexData.roundnessX, faceVertexData.roundnessY]

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/cpu/voxels-renderable-factory-cpu.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/cpu/voxels-renderable-factory-cpu.ts
@@ -94,19 +94,20 @@ class VoxelsRenderableFactoryCpu extends VoxelsRenderableFactory {
                 }
             };
 
-            const voxelsChunkCache = this.buildLocalMapCache(voxelsChunkData);
-            for (const faceData of this.iterateOnVisibleFacesWithCache(voxelsChunkCache)) {
-                let faceNoiseId: number;
-                if (faceData.voxelIsCheckerboard) {
-                    faceNoiseId =
-                        (this.checkerboardPattern.x * faceData.voxelLocalPosition.x +
-                            this.checkerboardPattern.y * faceData.voxelLocalPosition.y +
-                            this.checkerboardPattern.z * faceData.voxelLocalPosition.z) %
+            const computeFaceNoiseId = (voxelIsCheckerboard: boolean, voxelLocalPosition: THREE.Vector3Like) => {
+                if (voxelIsCheckerboard) {
+                    return (this.checkerboardPattern.x * voxelLocalPosition.x +
+                        this.checkerboardPattern.y * voxelLocalPosition.y +
+                        this.checkerboardPattern.z * voxelLocalPosition.z) %
                         2;
                 } else {
-                    faceNoiseId = 2 + Math.floor(Math.random() * (this.vertexData2Encoder.faceNoiseId.maxValue - 2));
+                    return 2 + Math.floor(Math.random() * (this.vertexData2Encoder.faceNoiseId.maxValue - 2));
                 }
+            };
 
+            const voxelsChunkCache = this.buildLocalMapCache(voxelsChunkData);
+            for (const faceData of this.iterateOnVisibleFacesWithCache(voxelsChunkCache)) {
+                const faceNoiseId = computeFaceNoiseId(faceData.voxelIsCheckerboard, faceData.voxelLocalPosition);
                 registerFace(faceData, faceNoiseId);
             }
 

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/cpu/voxels-renderable-factory-cpu.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/cpu/voxels-renderable-factory-cpu.ts
@@ -47,6 +47,10 @@ class VoxelsRenderableFactoryCpu extends VoxelsRenderableFactory {
         },
 
         buildBuffer(voxelsChunkData: VoxelsChunkData): Uint32Array {
+            if (voxelsChunkData.isEmpty) {
+                return new Uint32Array();
+            }
+
             const innerChunkSize = {
                 x: voxelsChunkData.size.x - 2,
                 y: voxelsChunkData.size.y - 2,

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/cpu/voxels-renderable-factory-cpu.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/cpu/voxels-renderable-factory-cpu.ts
@@ -7,7 +7,7 @@ import {
     type VertexData,
     type VoxelsChunkData,
 } from '../../voxels-renderable-factory-base';
-import { CheckerboardCellId } from '../vertex-data2-encoder';
+import { type CheckerboardCellId } from '../vertex-data2-encoder';
 import { VoxelsRenderableFactory } from '../voxels-renderable-factory';
 
 type FaceData = {
@@ -102,11 +102,12 @@ class VoxelsRenderableFactoryCpu extends VoxelsRenderableFactory {
                 if (!voxelIsCheckerboard) {
                     return 0;
                 }
-                const color = this.checkerboardPattern.x * voxelLocalPosition.x +
+                const color =
+                    this.checkerboardPattern.x * voxelLocalPosition.x +
                     this.checkerboardPattern.y * voxelLocalPosition.y +
                     this.checkerboardPattern.z * voxelLocalPosition.z;
 
-                return 1 + (color % 2) as CheckerboardCellId;
+                return (1 + (color % 2)) as CheckerboardCellId;
             };
 
             const voxelsChunkCache = this.buildLocalMapCache(voxelsChunkData);
@@ -135,18 +136,21 @@ class VoxelsRenderableFactoryCpu extends VoxelsRenderableFactory {
                     const referenceFaceData = referenceFacesData[faceData.faceType];
                     if (referenceFaceData) {
                         let mergeWithPreviousFace =
-                            (referenceFaceData.faceData.voxelMaterialId === faceData.voxelMaterialId) &&
-                            (!referenceFaceData.faceData.voxelIsCheckerboard) &&
-                            (!faceData.voxelIsCheckerboard) &&
-                            (referenceFaceData.faceData.voxelLocalPosition.x + referenceFaceData.repeatX + 1 === faceData.voxelLocalPosition.x) &&
-                            (referenceFaceData.faceData.voxelLocalPosition.y === faceData.voxelLocalPosition.y) &&
-                            (referenceFaceData.faceData.voxelLocalPosition.z === faceData.voxelLocalPosition.z) &&
-                            (!['left', 'right'].includes(referenceFaceData.faceData.faceType));
+                            referenceFaceData.faceData.voxelMaterialId === faceData.voxelMaterialId &&
+                            !referenceFaceData.faceData.voxelIsCheckerboard &&
+                            !faceData.voxelIsCheckerboard &&
+                            referenceFaceData.faceData.voxelLocalPosition.x + referenceFaceData.repeatX + 1 ===
+                                faceData.voxelLocalPosition.x &&
+                            referenceFaceData.faceData.voxelLocalPosition.y === faceData.voxelLocalPosition.y &&
+                            referenceFaceData.faceData.voxelLocalPosition.z === faceData.voxelLocalPosition.z &&
+                            !['left', 'right'].includes(referenceFaceData.faceData.faceType);
 
                         for (let iV = 0; iV < 4 && mergeWithPreviousFace; iV++) {
                             mergeWithPreviousFace &&= referenceFaceData.faceData.verticesData[iV]!.ao === faceData.verticesData[iV]!.ao;
-                            mergeWithPreviousFace &&= referenceFaceData.faceData.verticesData[iV]!.roundnessX === faceData.verticesData[iV]!.roundnessX;
-                            mergeWithPreviousFace &&= referenceFaceData.faceData.verticesData[iV]!.roundnessY === faceData.verticesData[iV]!.roundnessY;
+                            mergeWithPreviousFace &&=
+                                referenceFaceData.faceData.verticesData[iV]!.roundnessX === faceData.verticesData[iV]!.roundnessX;
+                            mergeWithPreviousFace &&=
+                                referenceFaceData.faceData.verticesData[iV]!.roundnessY === faceData.verticesData[iV]!.roundnessY;
                         }
 
                         if (mergeWithPreviousFace) {

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/cpu/voxels-renderable-factory-cpu.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/cpu/voxels-renderable-factory-cpu.ts
@@ -73,11 +73,11 @@ class VoxelsRenderableFactoryCpu extends VoxelsRenderableFactory {
             };
 
             const verticesData1 = new Uint32Array(4);
-            const registerFace = (faceData: FaceData, checkerboardCellId: CheckerboardCellId, _repeatX: number) => {
+            const registerFace = (faceData: FaceData, checkerboardCellId: CheckerboardCellId, repeatX: number) => {
                 faceData.verticesData.forEach((faceVertexData: VertexData, faceVertexIndex: number) => {
                     verticesData1[faceVertexIndex] = this.vertexData1Encoder.encode(
                         {
-                            x: faceData.voxelLocalPosition.x + faceVertexData.localPosition.x * (1 + 0),
+                            x: faceData.voxelLocalPosition.x + faceVertexData.localPosition.x * (1 + repeatX),
                             y: faceData.voxelLocalPosition.y + faceVertexData.localPosition.y,
                             z: faceData.voxelLocalPosition.z + faceVertexData.localPosition.z,
                         },

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/gpu/voxels-computer-gpu.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/gpu/voxels-computer-gpu.ts
@@ -163,11 +163,12 @@ class VoxelsComputerGpu {
                         let vertex${faceVertexId}Data = encodeVertexData1(encodedVoxelPosition, vertex${faceVertexId}Position, ao, u32(edgeRoundnessX), u32(edgeRoundnessY));`
                             )
                             .join('')}
+                        let voxelData2 = encodeVoxelData2(voxelMaterialId, faceNoiseId, ${face.normal.id}u, ${face.uvRight.id}u);
                         ${Cube.faceIndices
                             .map(
                                 (faceVertexId: number, index: number) => `
                         verticesBuffer.verticesData[2u * (firstVertexIndex + ${index}u) + 0u] = vertex${faceVertexId}Data;
-                        verticesBuffer.verticesData[2u * (firstVertexIndex + ${index}u) + 1u] = encodeVoxelData2(voxelMaterialId, faceNoiseId, ${face.normal.id}u, ${face.uvRight.id}u);`
+                        verticesBuffer.verticesData[2u * (firstVertexIndex + ${index}u) + 1u] = voxelData2;`
                             )
                             .join('')}
                     }`

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/gpu/voxels-computer-gpu.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/gpu/voxels-computer-gpu.ts
@@ -88,11 +88,9 @@ class VoxelsComputerGpu {
             let neighbourData = sampleVoxelsChunk(neighbourCacheIndex);
             return !${voxelmapDataPacking.wgslIsEmpty('neighbourData')};
         }
-        fn encodeVoxelData1(voxelPosition: vec3u) -> u32 {
-            return ${vertexData1Encoder.wgslEncodeVoxelData('voxelPosition')};
-        }
-        fn encodeVertexData1(encodedVoxelPosition: u32, verticePosition: vec3u, ao: u32, edgeRoundnessX: u32, edgeRoundnessY: u32) -> u32 {
-            return encodedVoxelPosition + ${vertexData1Encoder.wgslEncodeVertexData('verticePosition', 'ao', 'edgeRoundnessX', 'edgeRoundnessY')};
+        fn encodeVertexData1(voxelPosition: vec3u, verticePosition: vec3u, ao: u32, edgeRoundnessX: u32, edgeRoundnessY: u32) -> u32 {
+            let position = voxelPosition + verticePosition;
+            return ${vertexData1Encoder.wgslEncodeVertexData('position', 'ao', 'edgeRoundnessX', 'edgeRoundnessY')};
         }
         fn encodeVoxelData2(voxelMaterialId: u32, checkerboardCellid: u32, normalId: u32, uvRightId: u32) -> u32 {
             return ${vertexData2Encoder.wgslEncodeVoxelData('voxelMaterialId', 'checkerboardCellid', 'normalId', 'uvRightId')};
@@ -123,7 +121,6 @@ class VoxelsComputerGpu {
                 let voxelData: u32 = sampleVoxelsChunk(cacheIndex);
                 if (!${voxelmapDataPacking.wgslIsEmpty('voxelData')}) {
                     let voxelMaterialId: u32 = ${voxelmapDataPacking.wgslGetMaterialId('voxelData')};
-                    let encodedVoxelPosition = ${vertexData1Encoder.wgslEncodeVoxelData('voxelLocalPosition')};
                     let isCheckerboard = ${voxelmapDataPacking.wgslIsCheckerboard('voxelData')};
                     ${Object.values(Cube.faces)
                         .map(
@@ -158,7 +155,7 @@ class VoxelsComputerGpu {
                             .map(neighbour => `!doesNeighbourExist(cacheIndex, vec3i(${vec3ToString(neighbour, ', ')}))`)
                             .join(' && ')};
                         let vertex${faceVertexId}Position = vec3u(${faceVertex.vertex.x}u, ${faceVertex.vertex.y}u, ${faceVertex.vertex.z}u);
-                        let vertex${faceVertexId}Data = encodeVertexData1(encodedVoxelPosition, vertex${faceVertexId}Position, ao, u32(edgeRoundnessX), u32(edgeRoundnessY));`
+                        let vertex${faceVertexId}Data = encodeVertexData1(voxelLocalPosition, vertex${faceVertexId}Position, ao, u32(edgeRoundnessX), u32(edgeRoundnessY));`
                             )
                             .join('')}
                         let voxelData2 = encodeVoxelData2(voxelMaterialId, checkerboardCellId, ${face.normal.id}u, ${face.uvRight.id}u);

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/vertex-data1-encoder.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/vertex-data1-encoder.ts
@@ -4,65 +4,48 @@ import { PackedUintFactory, type PackedUintFragment } from '../../../../../helpe
 
 class VertexData1Encoder {
     private readonly packedUintFactory = new PackedUintFactory(32);
-    public readonly voxelX: PackedUintFragment;
-    public readonly voxelY: PackedUintFragment;
-    public readonly voxelZ: PackedUintFragment;
-    public readonly localX: PackedUintFragment;
-    public readonly localY: PackedUintFragment;
-    public readonly localZ: PackedUintFragment;
+    public readonly positionX: PackedUintFragment;
+    public readonly positionY: PackedUintFragment;
+    public readonly positionZ: PackedUintFragment;
     public readonly faceId: PackedUintFragment;
     public readonly ao: PackedUintFragment;
     public readonly edgeRoundness: PackedUintFragment;
 
     public constructor(maxVoxelsChunkSize: VoxelsChunkSize) {
-        this.voxelX = this.packedUintFactory.encodePart(maxVoxelsChunkSize.xz);
-        this.voxelY = this.packedUintFactory.encodePart(maxVoxelsChunkSize.y);
-        this.voxelZ = this.packedUintFactory.encodePart(maxVoxelsChunkSize.xz);
-        this.localX = this.packedUintFactory.encodePart(2);
-        this.localY = this.packedUintFactory.encodePart(2);
-        this.localZ = this.packedUintFactory.encodePart(2);
+        this.positionX = this.packedUintFactory.encodePart(maxVoxelsChunkSize.xz + 1);
+        this.positionY = this.packedUintFactory.encodePart(maxVoxelsChunkSize.y + 1);
+        this.positionZ = this.packedUintFactory.encodePart(maxVoxelsChunkSize.xz + 1);
         this.faceId = this.packedUintFactory.encodePart(6);
         this.ao = this.packedUintFactory.encodePart(4);
         this.edgeRoundness = this.packedUintFactory.encodePart(4);
     }
 
     public encode(
-        voxelPos: THREE.Vector3Like,
-        localPos: THREE.Vector3Like,
+        position: THREE.Vector3Like,
         faceId: number,
         ao: number,
         edgeRoundness: [boolean, boolean]
     ): number {
         return (
-            this.voxelX.encode(voxelPos.x) +
-            this.voxelY.encode(voxelPos.y) +
-            this.voxelZ.encode(voxelPos.z) +
-            this.localX.encode(localPos.x) +
-            this.localY.encode(localPos.y) +
-            this.localZ.encode(localPos.z) +
+            this.positionX.encode(position.x) +
+            this.positionY.encode(position.y) +
+            this.positionZ.encode(position.z) +
             this.faceId.encode(faceId) +
             this.ao.encode(ao) +
             this.edgeRoundness.encode(+edgeRoundness[0] + (+edgeRoundness[1] << 1))
         );
     }
 
-    public wgslEncodeVoxelData(voxelPosVarname: string): string {
-        return `(${this.voxelX.wgslEncode(voxelPosVarname + '.x')} + ${this.voxelY.wgslEncode(voxelPosVarname + '.y')} + ${this.voxelZ.wgslEncode(voxelPosVarname + '.z')})`;
-    }
-
-    public wgslEncodeVertexData(localPosVarname: string, aoVarname: string, edgeRoundessX: string, edgeRoundnessY: string): string {
-        return `(${this.localX.wgslEncode(localPosVarname + '.x')} + ${this.localY.wgslEncode(localPosVarname + '.y')} + ${this.localZ.wgslEncode(localPosVarname + '.z')} +
+    public wgslEncodeVertexData(positionVarname: string, aoVarname: string, edgeRoundessX: string, edgeRoundnessY: string): string {
+        return `(${this.positionX.wgslEncode(positionVarname + '.x')} + ${this.positionY.wgslEncode(positionVarname + '.y')} + ${this.positionZ.wgslEncode(positionVarname + '.z')} +
             ${this.ao.wgslEncode(aoVarname)} + ${this.edgeRoundness.wgslEncode(`(${edgeRoundessX} + (${edgeRoundnessY} << 1u))`)})`;
     }
 
     public serialize(): string {
         return `{
-        voxelX: ${this.voxelX.serialize()},
-        voxelY: ${this.voxelY.serialize()},
-        voxelZ: ${this.voxelZ.serialize()},
-        localX: ${this.localX.serialize()},
-        localY: ${this.localY.serialize()},
-        localZ: ${this.localZ.serialize()},
+        positionX: ${this.positionX.serialize()},
+        positionY: ${this.positionY.serialize()},
+        positionZ: ${this.positionZ.serialize()},
         faceId: ${this.faceId.serialize()},
         ao: ${this.ao.serialize()},
         edgeRoundness: ${this.edgeRoundness.serialize()},

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/vertex-data1-encoder.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/vertex-data1-encoder.ts
@@ -20,12 +20,7 @@ class VertexData1Encoder {
         this.edgeRoundness = this.packedUintFactory.encodePart(4);
     }
 
-    public encode(
-        position: THREE.Vector3Like,
-        faceId: number,
-        ao: number,
-        edgeRoundness: [boolean, boolean]
-    ): number {
+    public encode(position: THREE.Vector3Like, faceId: number, ao: number, edgeRoundness: [boolean, boolean]): number {
         return (
             this.positionX.encode(position.x) +
             this.positionY.encode(position.y) +

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/vertex-data2-encoder.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/vertex-data2-encoder.ts
@@ -1,16 +1,21 @@
 import { PackedUintFactory } from '../../../../../helpers/uint-packing';
 
+type CheckerboardCellId =
+    0 | // not a checkerboard cell
+    1 | // light checkerboard cell
+    2;  // dark checkerboard cell
+
 class VertexData2Encoder {
     private readonly packedUintFactory = new PackedUintFactory(32);
     public readonly voxelMaterialId = this.packedUintFactory.encodePart(1 << 15);
-    public readonly faceNoiseId = this.packedUintFactory.encodePart(16);
+    public readonly checkerboardCellId = this.packedUintFactory.encodePart(3);
     public readonly normalId = this.packedUintFactory.encodePart(6);
     public readonly uvRightId = this.packedUintFactory.encodePart(6);
 
-    public encode(voxelMaterialId: number, faceNoiseId: number, normalId: number, uvRightId: number): number {
+    public encode(voxelMaterialId: number, checkerboardCellId: CheckerboardCellId, normalId: number, uvRightId: number): number {
         return (
             this.voxelMaterialId.encode(voxelMaterialId) +
-            this.faceNoiseId.encode(faceNoiseId) +
+            this.checkerboardCellId.encode(checkerboardCellId) +
             this.normalId.encode(normalId) +
             this.uvRightId.encode(uvRightId)
         );
@@ -18,18 +23,18 @@ class VertexData2Encoder {
 
     public wgslEncodeVoxelData(
         voxelMaterialIdVarname: string,
-        faceNoiseIdVarname: string,
+        checkerboardCellIdVarname: string,
         normalIdVarname: string,
         uvRightIdVarname: string
     ): string {
-        return `(${this.voxelMaterialId.wgslEncode(voxelMaterialIdVarname)} + ${this.faceNoiseId.wgslEncode(faceNoiseIdVarname)}
+        return `(${this.voxelMaterialId.wgslEncode(voxelMaterialIdVarname)} + ${this.checkerboardCellId.wgslEncode(checkerboardCellIdVarname)}
         + ${this.normalId.wgslEncode(normalIdVarname)} + ${this.uvRightId.wgslEncode(uvRightIdVarname)})`;
     }
 
     public serialize(): string {
         return `{
         voxelMaterialId: ${this.voxelMaterialId.serialize()},
-        faceNoiseId: ${this.faceNoiseId.serialize()},
+        checkerboardCellId: ${this.checkerboardCellId.serialize()},
         normalId: ${this.normalId.serialize()},
         uvRightId: ${this.uvRightId.serialize()},
         ${this.encode.toString()},
@@ -37,4 +42,5 @@ class VertexData2Encoder {
     }
 }
 
-export { VertexData2Encoder };
+export { VertexData2Encoder, type CheckerboardCellId };
+

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/vertex-data2-encoder.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/vertex-data2-encoder.ts
@@ -1,9 +1,9 @@
 import { PackedUintFactory } from '../../../../../helpers/uint-packing';
 
 type CheckerboardCellId =
-    0 | // not a checkerboard cell
-    1 | // light checkerboard cell
-    2;  // dark checkerboard cell
+    | 0 // not a checkerboard cell
+    | 1 // light checkerboard cell
+    | 2; // dark checkerboard cell
 
 class VertexData2Encoder {
     private readonly packedUintFactory = new PackedUintFactory(32);
@@ -43,4 +43,3 @@ class VertexData2Encoder {
 }
 
 export { VertexData2Encoder, type CheckerboardCellId };
-

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/voxels-renderable-factory.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/voxels-renderable-factory.ts
@@ -88,18 +88,11 @@ out float vAo;
 
 void main() {`,
                 '#include <begin_vertex>': `
-    uvec3 modelVoxelPosition = uvec3(
-        ${this.vertexData1Encoder.voxelX.glslDecode(VoxelsRenderableFactory.data1AttributeName)},
-        ${this.vertexData1Encoder.voxelY.glslDecode(VoxelsRenderableFactory.data1AttributeName)},
-        ${this.vertexData1Encoder.voxelZ.glslDecode(VoxelsRenderableFactory.data1AttributeName)}
-    );
-
-    uvec3 localVertexPosition = uvec3(
-        ${this.vertexData1Encoder.localX.glslDecode(VoxelsRenderableFactory.data1AttributeName)},
-        ${this.vertexData1Encoder.localY.glslDecode(VoxelsRenderableFactory.data1AttributeName)},
-        ${this.vertexData1Encoder.localZ.glslDecode(VoxelsRenderableFactory.data1AttributeName)}
-    );
-    vec3 modelPosition = vec3(modelVoxelPosition + localVertexPosition);
+    vec3 modelPosition = vec3(uvec3(
+        ${this.vertexData1Encoder.positionX.glslDecode(VoxelsRenderableFactory.data1AttributeName)},
+        ${this.vertexData1Encoder.positionY.glslDecode(VoxelsRenderableFactory.data1AttributeName)},
+        ${this.vertexData1Encoder.positionZ.glslDecode(VoxelsRenderableFactory.data1AttributeName)}
+    ));
     vec3 transformed = modelPosition;
     
 #if defined(${cstVoxelRounded}) || defined(${cstVoxelNoise}) || defined(${cstVoxelGrid})
@@ -293,18 +286,11 @@ void main() {
             const uint vertexIds[] = uint[](${Cube.faceIndices.map(indice => `${indice}u`).join(', ')});
             uint vertexId = vertexIds[gl_VertexID % 6];
 
-            uvec3 modelVoxelPosition = uvec3(
-                ${this.vertexData1Encoder.voxelX.glslDecode(VoxelsRenderableFactory.data1AttributeName)},
-                ${this.vertexData1Encoder.voxelY.glslDecode(VoxelsRenderableFactory.data1AttributeName)},
-                ${this.vertexData1Encoder.voxelZ.glslDecode(VoxelsRenderableFactory.data1AttributeName)}
-            );
-
-            uvec3 localVertexPosition = uvec3(
-                ${this.vertexData1Encoder.localX.glslDecode(VoxelsRenderableFactory.data1AttributeName)},
-                ${this.vertexData1Encoder.localY.glslDecode(VoxelsRenderableFactory.data1AttributeName)},
-                ${this.vertexData1Encoder.localZ.glslDecode(VoxelsRenderableFactory.data1AttributeName)}
-            );
-            vec3 modelPosition = vec3(modelVoxelPosition + localVertexPosition);
+            vec3 modelPosition = vec3(uvec3(
+                ${this.vertexData1Encoder.positionX.glslDecode(VoxelsRenderableFactory.data1AttributeName)},
+                ${this.vertexData1Encoder.positionY.glslDecode(VoxelsRenderableFactory.data1AttributeName)},
+                ${this.vertexData1Encoder.positionZ.glslDecode(VoxelsRenderableFactory.data1AttributeName)}
+            ));
             gl_Position = projectionMatrix * modelViewMatrix * vec4(modelPosition, 1.0);
 
             vHighPrecisionZW = gl_Position.zw;
@@ -343,9 +329,9 @@ void main() {
 
         this.vertexData1Encoder = new VertexData1Encoder(params.maxVoxelsChunkSize);
         this.maxVoxelsChunkSize = new THREE.Vector3(
-            this.vertexData1Encoder.voxelX.maxValue + 1,
-            this.vertexData1Encoder.voxelY.maxValue + 1,
-            this.vertexData1Encoder.voxelZ.maxValue + 1
+            params.maxVoxelsChunkSize.xz,
+            params.maxVoxelsChunkSize.y,
+            params.maxVoxelsChunkSize.xz,
         );
 
         this.materialsTemplates = this.buildVoxelsMaterials();

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/voxels-renderable-factory.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/voxels-renderable-factory.ts
@@ -331,7 +331,7 @@ void main() {
         this.maxVoxelsChunkSize = new THREE.Vector3(
             params.maxVoxelsChunkSize.xz,
             params.maxVoxelsChunkSize.y,
-            params.maxVoxelsChunkSize.xz,
+            params.maxVoxelsChunkSize.xz
         );
 
         this.materialsTemplates = this.buildVoxelsMaterials();

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/voxels-renderable-factory.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/voxels-renderable-factory.ts
@@ -88,9 +88,6 @@ out float vAo;
 
 void main() {`,
                 '#include <begin_vertex>': `
-    const uint vertexIds[] = uint[](${Cube.faceIndices.map(indice => `${indice}u`).join(', ')});
-    uint vertexId = vertexIds[gl_VertexID % 6];
-
     uvec3 modelVoxelPosition = uvec3(
         ${this.vertexData1Encoder.voxelX.glslDecode(VoxelsRenderableFactory.data1AttributeName)},
         ${this.vertexData1Encoder.voxelY.glslDecode(VoxelsRenderableFactory.data1AttributeName)},
@@ -107,11 +104,13 @@ void main() {`,
     
 #if defined(${cstVoxelRounded}) || defined(${cstVoxelNoise}) || defined(${cstVoxelGrid})
     const vec2 uvs[] = vec2[](
-            vec2(0,0),
-            vec2(0,1),
-            vec2(1,0),
-            vec2(1,1)
-        );
+        vec2(0,0),
+        vec2(0,1),
+        vec2(1,0),
+        vec2(1,1)
+    );
+    const uint vertexIds[] = uint[](${Cube.faceIndices.map(indice => `${indice}u`).join(', ')});
+    uint vertexId = vertexIds[gl_VertexID % 6];
     vUv = uvs[vertexId];
 #endif // ${cstVoxelRounded} || ${cstVoxelNoise} || ${cstVoxelGrid}
 

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/voxels-renderable-factory-base.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/voxels-renderable-factory-base.ts
@@ -173,13 +173,13 @@ abstract class VoxelsRenderableFactoryBase {
     private static buildNoiseTexture(resolution: number): THREE.DataTexture {
         const textureWidth = resolution;
         const textureHeight = resolution;
-        const textureData = new Uint8Array(4 * textureWidth * textureHeight);
+        const textureData = new Uint8Array(textureWidth * textureHeight);
 
         for (let i = 0; i < textureData.length; i++) {
             textureData[i] = 256 * Math.random();
         }
 
-        return new THREE.DataTexture(textureData, textureWidth, textureHeight);
+        return new THREE.DataTexture(textureData, textureWidth, textureHeight, THREE.RedFormat);
     }
 }
 

--- a/src/lib/three-usage.ts
+++ b/src/lib/three-usage.ts
@@ -10,6 +10,7 @@ export {
     InterleavedBufferAttribute,
     Mesh,
     MeshPhongMaterial,
+    RedFormat,
     RedIntegerFormat,
     ShaderMaterial,
     Sphere,


### PR DESCRIPTION
This PR implements a simplified greedy-meshing.
This greedy-meshing only merges identical faces in the X-axis.
It results in about 17% fewer triangles on average.

This PR also implements various shader optimizations, resulting in about 10-15% fps increase.

In total, for a typical scene this PR increases the FPS by around 30%.