### PR TITLE
refactor/simplify_empty_chunks_usage

### DIFF
--- a/src/lib/terrain/voxelmap/patch/patch-factory/patch-factory-base.ts
+++ b/src/lib/terrain/voxelmap/patch/patch-factory/patch-factory-base.ts
@@ -1,9 +1,10 @@
-import * as THREE from '../../../../libs/three-usage';
 import { processAsap } from '../../../../helpers/async/async-sync';
 import { vec3ToString } from '../../../../helpers/string';
-import { type VoxelsChunkOrdering, type IVoxelMap } from '../../i-voxelmap';
+import * as THREE from '../../../../libs/three-usage';
+import { type IVoxelMap } from '../../i-voxelmap';
 import { type VoxelsRenderable } from '../../voxelsRenderable/voxels-renderable';
 import {
+    type VoxelsChunkDataNotEmpty,
     type VoxelsChunkData,
     type VoxelsRenderableFactoryBase,
 } from '../../voxelsRenderable/voxelsRenderableFactory/voxels-renderable-factory-base';
@@ -14,13 +15,6 @@ type VertexData = {
     readonly ao: number;
     readonly roundnessX: boolean;
     readonly roundnessY: boolean;
-};
-
-type LocalMapData = {
-    readonly size: THREE.Vector3;
-    readonly data: Uint16Array;
-    readonly dataOrdering: VoxelsChunkOrdering;
-    readonly isEmpty: boolean;
 };
 
 abstract class PatchFactoryBase {
@@ -55,7 +49,7 @@ abstract class PatchFactoryBase {
         patchId: PatchId,
         patchStart: THREE.Vector3,
         patchEnd: THREE.Vector3,
-        voxelsChunkData: VoxelsChunkData
+        voxelsChunkData: VoxelsChunkDataNotEmpty
     ): Promise<VoxelsRenderable | null> {
         patchStart = patchStart.clone();
         patchEnd = patchEnd.clone();
@@ -76,8 +70,8 @@ abstract class PatchFactoryBase {
         return this.finalizePatch(voxelsRenderable, patchId, patchStart);
     }
 
-    public async buildVoxelsRenderable(voxelsChunkData: VoxelsChunkData): Promise<VoxelsRenderable | null> {
-        return await this.voxelsRenderableFactory.buildVoxelsRenderable(voxelsChunkData);
+    public buildVoxelsRenderable(voxelsChunkData: VoxelsChunkData): null | Promise<VoxelsRenderable | null> {
+        return this.voxelsRenderableFactory.buildVoxelsRenderable(voxelsChunkData);
     }
 
     public dispose(): void {
@@ -90,7 +84,7 @@ abstract class PatchFactoryBase {
         map: IVoxelMap
     ): Promise<VoxelsRenderable | null>;
 
-    protected static async buildLocalMapData(patchStart: THREE.Vector3, patchEnd: THREE.Vector3, map: IVoxelMap): Promise<LocalMapData> {
+    protected static async buildLocalMapData(patchStart: THREE.Vector3, patchEnd: THREE.Vector3, map: IVoxelMap): Promise<VoxelsChunkData> {
         const cacheStart = patchStart.clone().subScalar(1);
         const cacheEnd = patchEnd.clone().addScalar(1);
         const cacheSize = new THREE.Vector3().subVectors(cacheEnd, cacheStart);
@@ -124,4 +118,4 @@ abstract class PatchFactoryBase {
     }
 }
 
-export { PatchFactoryBase, type LocalMapData, type VertexData };
+export { PatchFactoryBase, type VertexData };

--- a/src/lib/terrain/voxelmap/viewer/simple/voxelmap-viewer.ts
+++ b/src/lib/terrain/voxelmap/viewer/simple/voxelmap-viewer.ts
@@ -2,7 +2,7 @@ import { AsyncTask } from '../../../../helpers/async/async-task';
 import { PromisesQueue } from '../../../../helpers/async/promises-queue';
 import { vec3ToString } from '../../../../helpers/string';
 import * as THREE from '../../../../libs/three-usage';
-import { type VoxelsChunkOrdering, type IVoxelMaterial, type VoxelsChunkSize } from '../../i-voxelmap';
+import { type IVoxelMaterial, type VoxelsChunkOrdering, type VoxelsChunkSize } from '../../i-voxelmap';
 import { PatchFactoryCpu } from '../../patch/patch-factory/merged/patch-factory-cpu';
 import { PatchFactoryCpuWorker } from '../../patch/patch-factory/merged/patch-factory-cpu-worker';
 import { PatchFactoryGpuSequential } from '../../patch/patch-factory/merged/patch-factory-gpu-sequential';
@@ -162,6 +162,9 @@ class VoxelmapViewer extends VoxelmapViewerBase {
                 id: patchId,
                 status: 'in-queue',
                 computationTask: new AsyncTask<VoxelsRenderable | null>(async () => {
+                    if (voxelsChunkData.isEmpty) {
+                        return null;
+                    }
                     const patchStart = new THREE.Vector3().multiplyVectors(patchId, this.patchSize);
                     const patchEnd = new THREE.Vector3().addVectors(patchStart, this.patchSize);
                     return await this.patchFactory.buildPatchFromVoxelsChunk(patchId, patchStart, patchEnd, voxelsChunkData);

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/cpu/voxels-renderable-factory-cpu-worker.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/cpu/voxels-renderable-factory-cpu-worker.ts
@@ -1,7 +1,7 @@
 import { type WorkerDefinition } from '../../../../../../helpers/async/dedicatedWorkers/dedicated-worker';
 import { DedicatedWorkersPool } from '../../../../../../helpers/async/dedicatedWorkers/dedicated-workers-pool';
-import { type VoxelsChunkOrdering, type IVoxelMaterial, type VoxelsChunkSize } from '../../../../i-voxelmap';
-import { type CheckerboardType, type VoxelsChunkData } from '../../voxels-renderable-factory-base';
+import { type IVoxelMaterial, type VoxelsChunkOrdering, type VoxelsChunkSize } from '../../../../i-voxelmap';
+import { type CheckerboardType, type VoxelsChunkDataNotEmpty } from '../../voxels-renderable-factory-base';
 
 import { VoxelsRenderableFactoryCpu } from './voxels-renderable-factory-cpu';
 
@@ -28,12 +28,12 @@ class VoxelsRenderableFactoryCpuWorker extends VoxelsRenderableFactoryCpu {
         this.workersPoolSize = params.workersPoolSize;
     }
 
-    protected override buildBuffer(voxelsChunkData: VoxelsChunkData): Promise<Uint32Array> {
+    protected override buildBuffer(voxelsChunkData: VoxelsChunkDataNotEmpty): Promise<Uint32Array> {
         if (!this.workersPool) {
             const workerDefinition: WorkerDefinition = {
                 commonCode: `const factory = ${this.serialize()};`,
                 tasks: {
-                    buildBuffer: (voxelsChunkData: VoxelsChunkData) => {
+                    buildBuffer: (voxelsChunkData: VoxelsChunkDataNotEmpty) => {
                         // eslint-disable-next-line no-eval
                         const factory2 = eval('factory') as VoxelsRenderableFactoryCpu['serializableFactory'];
                         const buffer = factory2.buildBuffer(voxelsChunkData);

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/cpu/voxels-renderable-factory-cpu.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/cpu/voxels-renderable-factory-cpu.ts
@@ -1,11 +1,12 @@
 import type * as THREE from '../../../../../../libs/three-usage';
-import { voxelmapDataPacking, type VoxelsChunkOrdering, type IVoxelMaterial, type VoxelsChunkSize } from '../../../../i-voxelmap';
+import { voxelmapDataPacking, type IVoxelMaterial, type VoxelsChunkOrdering, type VoxelsChunkSize } from '../../../../i-voxelmap';
 import * as Cube from '../../cube';
 import {
     type CheckerboardType,
     type GeometryAndMaterial,
     type VertexData,
     type VoxelsChunkData,
+    type VoxelsChunkDataNotEmpty,
 } from '../../voxels-renderable-factory-base';
 import { type CheckerboardCellId } from '../vertex-data2-encoder';
 import { VoxelsRenderableFactory } from '../voxels-renderable-factory';
@@ -53,7 +54,7 @@ class VoxelsRenderableFactoryCpu extends VoxelsRenderableFactory {
         greedyMeshing: true,
         voxelsChunkOrdering: 'zyx' as VoxelsChunkOrdering,
 
-        buildBuffer(voxelsChunkData: VoxelsChunkData): Uint32Array {
+        buildBuffer(voxelsChunkData: VoxelsChunkDataNotEmpty): Uint32Array {
             if (voxelsChunkData.isEmpty) {
                 return new Uint32Array();
             }
@@ -187,7 +188,7 @@ class VoxelsRenderableFactoryCpu extends VoxelsRenderableFactory {
             return new Uint32Array(bufferData.buffer.subarray(0, uint32PerVertex * bufferData.verticesCount));
         },
 
-        buildLocalMapCache(voxelsChunkData: VoxelsChunkData): VoxelsChunkCache {
+        buildLocalMapCache(voxelsChunkData: VoxelsChunkDataNotEmpty): VoxelsChunkCache {
             type Component = 'x' | 'y' | 'z';
             const buildIndexFactorComponent = (component: Component): number => {
                 const sanitizeXYZ = (s: string | undefined): Component => {
@@ -322,11 +323,7 @@ class VoxelsRenderableFactoryCpu extends VoxelsRenderableFactory {
         this.serializableFactory.voxelsChunkOrdering = params.voxelsChunkOrdering;
     }
 
-    public async buildGeometryAndMaterials(voxelsChunkData: VoxelsChunkData): Promise<GeometryAndMaterial[]> {
-        if (voxelsChunkData.isEmpty) {
-            return [];
-        }
-
+    public async buildGeometryAndMaterials(voxelsChunkData: VoxelsChunkDataNotEmpty): Promise<GeometryAndMaterial[]> {
         if (voxelsChunkData.dataOrdering !== this.serializableFactory.voxelsChunkOrdering) {
             throw new Error(
                 `Invalid data ordering: expected "${this.serializableFactory.voxelsChunkOrdering}" but received "${voxelsChunkData.dataOrdering}".`
@@ -337,7 +334,7 @@ class VoxelsRenderableFactoryCpu extends VoxelsRenderableFactory {
         return this.assembleGeometryAndMaterials(buffer);
     }
 
-    protected async buildBuffer(voxelsChunkData: VoxelsChunkData): Promise<Uint32Array> {
+    protected async buildBuffer(voxelsChunkData: VoxelsChunkDataNotEmpty): Promise<Uint32Array> {
         return this.serializableFactory.buildBuffer(voxelsChunkData);
     }
 

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/gpu/voxels-computer-gpu.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/gpu/voxels-computer-gpu.ts
@@ -1,13 +1,13 @@
 /// <reference types="@webgpu/types" />
 
-import type * as THREE from '../../../../../../libs/three-usage';
 import { PromisesQueue } from '../../../../../../helpers/async/promises-queue';
 import { logger } from '../../../../../../helpers/logger';
 import { vec3ToString } from '../../../../../../helpers/string';
 import { getGpuDevice } from '../../../../../../helpers/webgpu/webgpu-device';
+import type * as THREE from '../../../../../../libs/three-usage';
 import { voxelmapDataPacking, type VoxelsChunkOrdering } from '../../../../i-voxelmap';
 import * as Cube from '../../cube';
-import { type CheckerboardType, type VoxelsChunkData } from '../../voxels-renderable-factory-base';
+import { type VoxelsChunkDataNotEmpty, type CheckerboardType } from '../../voxels-renderable-factory-base';
 import { type VertexData1Encoder } from '../vertex-data1-encoder';
 import { type VertexData2Encoder } from '../vertex-data2-encoder';
 
@@ -240,7 +240,7 @@ class VoxelsComputerGpu {
         });
     }
 
-    public async computeBuffer(voxelsChunkData: VoxelsChunkData): Promise<ComputationOutputs> {
+    public async computeBuffer(voxelsChunkData: VoxelsChunkDataNotEmpty): Promise<ComputationOutputs> {
         if (voxelsChunkData.dataOrdering !== this.voxelsChunkOrdering) {
             throw new Error(
                 `Invalid data ordering: expected "${this.voxelsChunkOrdering}" but received "${voxelsChunkData.dataOrdering}".`

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/gpu/voxels-renderable-factory-gpu.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/gpu/voxels-renderable-factory-gpu.ts
@@ -1,5 +1,5 @@
-import { type VoxelsChunkOrdering, type IVoxelMaterial, type VoxelsChunkSize } from '../../../../i-voxelmap';
-import { type CheckerboardType, type GeometryAndMaterial, type VoxelsChunkData } from '../../voxels-renderable-factory-base';
+import { type IVoxelMaterial, type VoxelsChunkOrdering, type VoxelsChunkSize } from '../../../../i-voxelmap';
+import { type VoxelsChunkDataNotEmpty, type CheckerboardType, type GeometryAndMaterial } from '../../voxels-renderable-factory-base';
 import { VoxelsRenderableFactory } from '../voxels-renderable-factory';
 
 import { VoxelsComputerGpu } from './voxels-computer-gpu';
@@ -35,11 +35,7 @@ class VoxelsRenderableFactoryGpu extends VoxelsRenderableFactory {
         this.voxelsComputerGpuPromise?.then(computer => computer.dispose());
     }
 
-    public async buildGeometryAndMaterials(voxelsChunkData: VoxelsChunkData): Promise<GeometryAndMaterial[]> {
-        if (voxelsChunkData.isEmpty) {
-            return [];
-        }
-
+    public async buildGeometryAndMaterials(voxelsChunkData: VoxelsChunkDataNotEmpty): Promise<GeometryAndMaterial[]> {
         const voxelsComputerGpu = await this.getVoxelsComputerGpu();
         const buffer = await voxelsComputerGpu.computeBuffer(voxelsChunkData);
         return this.assembleGeometryAndMaterials(buffer);

--- a/src/test/map/trees/tree.ts
+++ b/src/test/map/trees/tree.ts
@@ -80,6 +80,9 @@ class Tree {
 
     public getVoxel(position: THREE.Vector3Like): number | null {
         const index = this.buildIndex(position);
+        if (this.voxels.isEmpty) {
+            return null;
+        }
         const voxel = this.voxels.data[index];
         if (typeof voxel === 'undefined') {
             throw new Error();


### PR DESCRIPTION
refactor: allow simplied input object for empty chunks

The `VoxelmapViewer.enqueuePatch` method now takes as input as `VoxelsChunkData` which is:
```ts
type VoxelsChunkDataEmpty = {
    readonly size: THREE.Vector3;
    readonly isEmpty: true;
};
type VoxelsChunkDataNotEmpty = {
    readonly size: THREE.Vector3;
    readonly data: Uint16Array;
    readonly dataOrdering: VoxelsChunkOrdering;
    readonly isEmpty: false;
};
type VoxelsChunkData = VoxelsChunkDataEmpty | VoxelsChunkDataNotEmpty;
```

which means if a chunk is empty, there is no need to send a big `Uint16Array` full of zeroes.

Also improve performance when processing those empty chunks.