### PR TITLE
Feat/custom specular

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -28,6 +28,7 @@ export {
     type VoxelsChunkData,
 } from './terrain/voxelmap/viewer/simple/voxelmap-viewer';
 export { VoxelmapVisibilityComputer } from './terrain/voxelmap/voxelmap-visibility-computer';
+export { EVoxelsDisplayMode } from './terrain/voxelmap/voxelsRenderable/voxels-material';
 export { type CheckerboardType } from './terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/voxels-renderable-factory-base';
 
 export { EVoxelStatus, type IVoxelmapCollider } from './physics/i-voxelmap-collider';

--- a/src/lib/terrain/terrain-viewer.ts
+++ b/src/lib/terrain/terrain-viewer.ts
@@ -15,10 +15,6 @@ class TerrainViewer {
     public readonly container: THREE.Object3D;
 
     public readonly parameters = {
-        shadows: {
-            cast: true,
-            receive: true,
-        },
         lod: {
             enabled: true,
             wireframe: false,

--- a/src/lib/terrain/voxelmap/i-voxelmap.ts
+++ b/src/lib/terrain/voxelmap/i-voxelmap.ts
@@ -13,6 +13,7 @@ type Color = {
 
 interface IVoxelMaterial {
     readonly color: Color;
+    readonly shininess?: number;
 }
 
 type VoxelsChunkSize = {

--- a/src/lib/terrain/voxelmap/viewer/voxelmap-viewer-base.ts
+++ b/src/lib/terrain/voxelmap/viewer/voxelmap-viewer-base.ts
@@ -52,6 +52,9 @@ abstract class VoxelmapViewerBase {
             thickness: 0.02,
             color: new THREE.Vector3(-0.1, -0.1, -0.1),
         },
+        specular: {
+            strength: 1,
+        },
     };
 
     public readonly minChunkIdY: number;
@@ -93,11 +96,13 @@ abstract class VoxelmapViewerBase {
             voxelsRenderable.parameters.ao.strength = voxelsSettings.ao.strength;
             voxelsRenderable.parameters.ao.spread = voxelsSettings.ao.spread;
 
-            voxelsRenderable.parameters.shadows = this.parameters.shadows;
+            voxelsRenderable.parameters.shadows = voxelsSettings.shadows;
 
             voxelsRenderable.parameters.grid.enabled = voxelsSettings.grid.enabled;
             voxelsRenderable.parameters.grid.thickness = voxelsSettings.grid.thickness;
             voxelsRenderable.parameters.grid.color = voxelsSettings.grid.color;
+
+            voxelsRenderable.parameters.specular.strength = Math.max(0.0001, voxelsSettings.specular.strength);
 
             voxelsRenderable.updateUniforms();
         }

--- a/src/lib/terrain/voxelmap/viewer/voxelmap-viewer-base.ts
+++ b/src/lib/terrain/voxelmap/viewer/voxelmap-viewer-base.ts
@@ -1,10 +1,11 @@
-import * as THREE from '../../../libs/three-usage';
 import { logger } from '../../../helpers/logger';
 import { createMeshesStatistics, type MeshesStatistics } from '../../../helpers/meshes-statistics';
+import * as THREE from '../../../libs/three-usage';
 import { type VoxelsChunkSize } from '../i-voxelmap';
 import { PatchId } from '../patch/patch-id';
 import { EVoxelsDisplayMode } from '../voxelsRenderable/voxels-material';
 import { type VoxelsRenderable } from '../voxelsRenderable/voxels-renderable';
+import { VoxelsRenderableFactoryBase } from '../voxelsRenderable/voxelsRenderableFactory/voxels-renderable-factory-base';
 
 type VoxelmapStatistics = MeshesStatistics & {
     patchSize: THREE.Vector3Like;
@@ -21,6 +22,9 @@ type ComputedPatch = {
 };
 
 abstract class VoxelmapViewerBase {
+    public readonly maxSmoothEdgeRadius = VoxelsRenderableFactoryBase.maxSmoothEdgeRadius;
+    public readonly maxShininess = VoxelsRenderableFactoryBase.maxShininess;
+
     public readonly container: THREE.Group;
 
     public readonly parameters = {

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxels-material.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxels-material.ts
@@ -17,6 +17,7 @@ type VoxelsMaterialUniforms = {
     readonly uSmoothEdgeRadius: { value: number };
     readonly uGridThickness: { value: number };
     readonly uGridColor: { value: THREE.Vector3 };
+    readonly uShininessStrength: { value: number };
 };
 
 type VoxelsMaterial = THREE.Material & {

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxels-renderable.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxels-renderable.ts
@@ -27,6 +27,9 @@ class VoxelsRenderable {
             radius: 0.1,
             quality: 2,
         },
+        specular: {
+            strength: 1,
+        },
         ao: {
             enabled: true,
             strength: 0.4,
@@ -108,6 +111,8 @@ class VoxelsRenderable {
 
                 uniforms.uGridThickness.value = +this.parameters.grid.enabled * this.parameters.grid.thickness;
                 uniforms.uGridColor.value = this.parameters.grid.color;
+
+                uniforms.uShininessStrength.value = this.parameters.specular.strength;
 
                 material.needsUpdate = true;
 

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/voxels-renderable-factory.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/merged/voxels-renderable-factory.ts
@@ -179,6 +179,8 @@ uniform vec3 uGridColor;
 uniform float uGridThickness;
 #endif // ${cstVoxelGrid}
 
+uniform float uShininessStrength;
+
 uniform uint uDisplayMode;
 
 uniform mat3 normalMatrix; // from three.js
@@ -258,7 +260,7 @@ VoxelMaterial getVoxelMaterial(const vec3 modelNormal) {
         ivec2 texelCoords = ivec2(voxelMaterialId % ${this.texture.image.width}u, voxelMaterialId / ${this.texture.image.width}u);
         vec4 fetchedTexel = texelFetch(uTexture, texelCoords, 0);
         voxelMaterial.color = fetchedTexel.rgb + noise;
-        voxelMaterial.shininess = ${VoxelsRenderableFactoryBase.maxShininess.toFixed(1)} * fetchedTexel.a * (1.0 + 10.0 * noise);
+        voxelMaterial.shininess = uShininessStrength * ${VoxelsRenderableFactoryBase.maxShininess.toFixed(1)} * fetchedTexel.a * (1.0 + 10.0 * noise);
     }
 
     if (uDisplayMode == ${EVoxelsDisplayMode.GREY}u) {

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/voxels-renderable-factory-base.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/voxels-renderable-factory-base.ts
@@ -85,6 +85,7 @@ abstract class VoxelsRenderableFactoryBase {
             uSmoothEdgeRadius: { value: 0 },
             uGridThickness: { value: 0.02 },
             uGridColor: { value: new THREE.Vector3(-0.2, -0.2, -0.2) },
+            uShininessStrength: { value: 1 },
         };
         this.uniformsTemplate.uTexture.value = this.texture;
     }

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/voxels-renderable-factory-base.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/voxels-renderable-factory-base.ts
@@ -44,6 +44,7 @@ type Parameters = {
 
 abstract class VoxelsRenderableFactoryBase {
     public static readonly maxSmoothEdgeRadius = 0.3;
+    public static readonly maxShininess = 400;
 
     public abstract readonly maxVoxelsChunkSize: THREE.Vector3;
 
@@ -164,7 +165,8 @@ abstract class VoxelsRenderableFactoryBase {
             textureData[4 * materialId + 0] = 255 * material.color.r;
             textureData[4 * materialId + 1] = 255 * material.color.g;
             textureData[4 * materialId + 2] = 255 * material.color.b;
-            textureData[4 * materialId + 3] = 255;
+            const shininess = material.shininess ?? 0;
+            textureData[4 * materialId + 3] = (255 * shininess) / VoxelsRenderableFactoryBase.maxShininess;
         });
         const texture = new THREE.DataTexture(textureData, textureWidth, textureHeight);
         texture.needsUpdate = true;

--- a/src/test/main.ts
+++ b/src/test/main.ts
@@ -2,6 +2,7 @@ import { ELogLevel, setVerbosity } from '../lib/index';
 
 import { VoxelMap } from './map/voxel-map';
 import { type TestBase } from './test-base';
+import { TestParticles } from './test-particles';
 import { TestPhysics } from './test-physics';
 import { TestTerrain } from './test-terrain';
 import { TestTerrainAutonomous } from './test-terrain-autonomous';
@@ -25,9 +26,10 @@ enum ETest {
     WEATHER,
     TEXTURE_CUSTOMIZATION,
     PHYSICS,
+    PARTICLES,
 }
 
-const test = ETest.PHYSICS as ETest;
+const test = ETest.TERRAIN as ETest;
 
 let testScene: TestBase;
 if (test === ETest.TERRAIN) {
@@ -40,6 +42,8 @@ if (test === ETest.TERRAIN) {
     testScene = new TestTextureCustomization();
 } else if (test === ETest.PHYSICS) {
     testScene = new TestPhysics(createVoxelMap());
+} else if (test === ETest.PARTICLES) {
+    testScene = new TestParticles(createVoxelMap());
 } else {
     throw new Error(`Unknown test "${test}".`);
 }

--- a/src/test/map/color-mapping.ts
+++ b/src/test/map/color-mapping.ts
@@ -16,7 +16,7 @@ class ColorMapping {
             for (leveled.g = 0; leveled.g < this.valuesCountPerChannel; leveled.g++) {
                 for (leveled.r = 0; leveled.r < this.valuesCountPerChannel; leveled.r++) {
                     const color = this.buildColorFromLeveled(leveled);
-                    this.materialsList.push({ color });
+                    this.materialsList.push({ color, shininess: 200 * Math.random() });
                 }
             }
         }

--- a/src/test/map/materials.ts
+++ b/src/test/map/materials.ts
@@ -13,13 +13,13 @@ enum EVoxelType {
 }
 
 const voxelMaterials: Record<EVoxelType, IVoxelMaterial> = [
-    { color: new THREE.Color('#ABABAB') },
-    { color: new THREE.Color('#00B920') },
-    { color: new THREE.Color('#E5E5E5') },
-    { color: new THREE.Color('#0055E2') },
-    { color: new THREE.Color('#DCBE28') },
-    { color: new THREE.Color('#692D00') },
-    { color: new THREE.Color('#007A00') },
+    { color: new THREE.Color('#ABABAB'), shininess: 0 },
+    { color: new THREE.Color('#00B920'), shininess: 1 },
+    { color: new THREE.Color('#E5E5E5'), shininess: 10 },
+    { color: new THREE.Color('#0055E2'), shininess: 30 },
+    { color: new THREE.Color('#DCBE28'), shininess: 10 },
+    { color: new THREE.Color('#692D00'), shininess: 0 },
+    { color: new THREE.Color('#007A00'), shininess: 5 },
 ];
 
 export { EVoxelType, voxelMaterials };

--- a/src/test/test-particles.ts
+++ b/src/test/test-particles.ts
@@ -3,12 +3,14 @@ import * as THREE from 'three-usage-test';
 import {
     BoardOverlaysHandler,
     BoardRenderableFactory,
+    BuffAscendEffect,
     computeBoard,
     EBoardSquareType,
     EComputationMethod,
     HeightmapViewer,
     InstancedBillboard,
     PromisesQueue,
+    Snow,
     TerrainViewer,
     VoxelmapViewer,
     VoxelmapVisibilityComputer,
@@ -21,10 +23,12 @@ import {
 
 import { LineOfSight } from './board/line-of-sight';
 import { PathFinder } from './board/path-finder';
+import { Fountain } from './effects/fire-fountain';
+import { Puff } from './effects/puff';
 import { type VoxelMap } from './map/voxel-map';
 import { TestTerrainBase, type ITerrainMap } from './test-terrain-base';
 
-class TestTerrain extends TestTerrainBase {
+class TestParticles extends TestTerrainBase {
     protected override readonly terrainViewer: TerrainViewer;
 
     private readonly voxelmapViewer: VoxelmapViewer;
@@ -38,8 +42,73 @@ class TestTerrain extends TestTerrainBase {
         readonly instancedBillboard: InstancedBillboard;
     } | null = null;
 
+    private readonly puff1: Puff;
+    private readonly puff2: Puff;
+    private readonly fountain: Fountain;
+    private readonly snow: Snow;
+    private readonly heal: BuffAscendEffect;
+
     public constructor(map: IVoxelMap & IHeightmap & ITerrainMap) {
         super(map);
+
+        this.puff1 = new Puff({
+            texture: new THREE.TextureLoader().load('/resources/puff.png', texture => {
+                texture.colorSpace = THREE.SRGBColorSpace;
+            }),
+            size: { x: 3, y: 3 },
+        });
+        this.puff1.container.position.set(-5.5, 200, 0.5);
+        // this.puff1.container.position.set(-5.5, 139.25, 0.5);
+        // this.puff1.container.scale.set(0.5, 0.5, 0.5);
+        this.scene.add(this.puff1.container);
+
+        this.puff2 = new Puff({
+            texture: new THREE.TextureLoader().load('/resources/puff2.png', texture => {
+                texture.colorSpace = THREE.SRGBColorSpace;
+            }),
+            size: { x: 10, y: 1 },
+        });
+        this.puff2.container.position.set(+5, 200, 0);
+        this.scene.add(this.puff2.container);
+
+        this.fountain = new Fountain(new THREE.Color(0xff3311));
+        this.fountain.container.position.set(5, 200, -10);
+        this.scene.add(this.fountain.container);
+
+        this.snow = new Snow(this.renderer);
+        this.snow.container.position.set(40, 170, -40);
+        this.scene.add(this.snow.container);
+
+        this.heal = new BuffAscendEffect({
+            size: { x: 2, y: 6, z: 2 },
+            density: 32,
+            animationDuration: 1500,
+            texture: new THREE.TextureLoader().load('/resources/heal.png', texture => {
+                texture.colorSpace = THREE.SRGBColorSpace;
+            }),
+        });
+        this.heal.container.position.set(0, 200, 0);
+        this.scene.add(this.heal.container);
+
+        let healRunning = false;
+        window.addEventListener('keydown', event => {
+            if (!healRunning && event.code === 'Space') {
+                this.heal.start();
+                healRunning = true;
+            }
+        });
+        window.addEventListener('keyup', event => {
+            if (healRunning && event.code === 'Space') {
+                this.heal.stop();
+                healRunning = false;
+            }
+        });
+        // setTimeout(() => {
+        //     // this.heal.startSingle().then(() => healRunning = false);
+        //     this.heal.start();
+
+        //     setTimeout(() => this.heal.stop(), 3000);
+        // }, 3000);
 
         const fakeCamera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 1000);
         const helper = new THREE.CameraHelper(fakeCamera);
@@ -207,6 +276,17 @@ return vec4(sampled.rgb / sampled.a, 1);
         this.applyVisibility();
     }
 
+    protected override update(): void {
+        super.update();
+
+        // this.puff1.update();
+        // this.puff2.update();
+        // this.fountain.update();
+        // this.heal.update();
+
+        this.snow.update(this.renderer, this.camera);
+    }
+
     private applyVisibility(): void {
         const patchesToDisplay = this.voxelmapVisibilityComputer.getRequestedPatches();
         const patchesIdToDisplay = patchesToDisplay.map(patchToDisplay => patchToDisplay.id);
@@ -357,4 +437,4 @@ return vec4(sampled.rgb / sampled.a, 1);
     }
 }
 
-export { TestTerrain };
+export { TestParticles };

--- a/src/test/test-particles.ts
+++ b/src/test/test-particles.ts
@@ -155,8 +155,8 @@ class TestParticles extends TestTerrainBase {
         });
 
         this.terrainViewer = new TerrainViewer(heightmapViewer, this.voxelmapViewer);
-        this.terrainViewer.parameters.shadows.cast = true;
-        this.terrainViewer.parameters.shadows.receive = true;
+        this.voxelmapViewer.parameters.shadows.cast = this.enableShadows;
+        this.voxelmapViewer.parameters.shadows.receive = this.enableShadows;
         // this.terrainViewer.parameters.lod.enabled = false;
         // this.terrainViewer.parameters.lod.wireframe = true;
         this.scene.add(this.terrainViewer.container);

--- a/src/test/test-terrain.ts
+++ b/src/test/test-terrain.ts
@@ -1,3 +1,4 @@
+import GUI from 'lil-gui';
 import * as THREE from 'three-usage-test';
 
 import {
@@ -6,6 +7,7 @@ import {
     computeBoard,
     EBoardSquareType,
     EComputationMethod,
+    EVoxelsDisplayMode,
     HeightmapViewer,
     InstancedBillboard,
     PromisesQueue,
@@ -170,6 +172,78 @@ return vec4(sampled.rgb / sampled.a, 1);
             }
         });
         this.promisesQueue = new PromisesQueue(this.voxelmapViewer.maxPatchesComputedInParallel + 5);
+
+        const gui = new GUI();
+        {
+            const texturingOptions = {
+                textured: EVoxelsDisplayMode.TEXTURED,
+                normals: EVoxelsDisplayMode.NORMALS,
+                grey: EVoxelsDisplayMode.GREY,
+            };
+
+            const voxelsFolder = gui.addFolder('Voxels');
+            voxelsFolder.open();
+            const parameters = {
+                shadows: this.enableShadows,
+                face: {
+                    texturing: Object.entries(texturingOptions).find(a => a[1] === this.voxelmapViewer.parameters.faces.displayMode)![0],
+                    noise: this.voxelmapViewer.parameters.faces.noiseContrast,
+                    checkerboard: this.voxelmapViewer.parameters.faces.checkerboardContrast,
+                },
+                edgeSmoothness: this.voxelmapViewer.parameters.smoothEdges.radius,
+                ao: { ...this.voxelmapViewer.parameters.ao },
+            };
+            voxelsFolder
+                .add(parameters, 'shadows')
+                .name('Enable shadows')
+                .onChange(() => {
+                    this.voxelmapViewer.parameters.shadows.cast = parameters.shadows;
+                    this.voxelmapViewer.parameters.shadows.receive = parameters.shadows;
+                });
+            voxelsFolder
+                .add(parameters.face, 'texturing', texturingOptions)
+                .name('Display mode')
+                .onChange(() => {
+                    this.voxelmapViewer.parameters.faces.displayMode = Number(parameters.face.texturing);
+                });
+            voxelsFolder
+                .add(parameters.face, 'noise', 0, 0.1, 0.001)
+                .name('Noise contrast')
+                .onChange(() => {
+                    this.voxelmapViewer.parameters.faces.noiseContrast = parameters.face.noise;
+                });
+            voxelsFolder
+                .add(parameters.face, 'checkerboard', 0, 0.2, 0.001)
+                .name('Checkerboard contrast')
+                .onChange(() => {
+                    this.voxelmapViewer.parameters.faces.checkerboardContrast = parameters.face.checkerboard;
+                });
+            voxelsFolder
+                .add(parameters, 'edgeSmoothness', 0, 0.2, 0.01)
+                .name('Edge smoothness')
+                .onChange(() => {
+                    this.voxelmapViewer.parameters.smoothEdges.radius = parameters.edgeSmoothness;
+                });
+
+            voxelsFolder
+                .add(parameters.ao, 'enabled')
+                .name('AO enabled')
+                .onChange(() => {
+                    this.voxelmapViewer.parameters.ao.enabled = parameters.ao.enabled;
+                });
+            voxelsFolder
+                .add(parameters.ao, 'spread', 0, 1)
+                .name('AO spread')
+                .onChange(() => {
+                    this.voxelmapViewer.parameters.ao.spread = parameters.ao.spread;
+                });
+            voxelsFolder
+                .add(parameters.ao, 'strength', 0, 1)
+                .name('AO strength')
+                .onChange(() => {
+                    this.voxelmapViewer.parameters.ao.strength = parameters.ao.strength;
+                });
+        }
     }
 
     private updateTreeBillboards(): void {

--- a/src/test/test-terrain.ts
+++ b/src/test/test-terrain.ts
@@ -90,7 +90,7 @@ class TestTerrain extends TestTerrainBase {
         this.terrainViewer = new TerrainViewer(heightmapViewer, this.voxelmapViewer);
         this.voxelmapViewer.parameters.shadows.cast = this.enableShadows;
         this.voxelmapViewer.parameters.shadows.receive = this.enableShadows;
-        // this.terrainViewer.parameters.lod.enabled = false;
+        this.terrainViewer.parameters.lod.enabled = false;
         // this.terrainViewer.parameters.lod.wireframe = true;
         this.scene.add(this.terrainViewer.container);
 
@@ -213,7 +213,7 @@ return vec4(sampled.rgb / sampled.a, 1);
                     this.voxelmapViewer.parameters.faces.noiseContrast = parameters.face.noise;
                 });
             voxelsFolder
-                .add(parameters.face, 'checkerboard', 0, 0.2, 0.001)
+                .add(parameters.face, 'checkerboard', 0, this.voxelmapViewer.maxSmoothEdgeRadius, 0.001)
                 .name('Checkerboard contrast')
                 .onChange(() => {
                     this.voxelmapViewer.parameters.faces.checkerboardContrast = parameters.face.checkerboard;

--- a/src/test/test-terrain.ts
+++ b/src/test/test-terrain.ts
@@ -192,6 +192,7 @@ return vec4(sampled.rgb / sampled.a, 1);
                 },
                 edgeSmoothness: this.voxelmapViewer.parameters.smoothEdges.radius,
                 ao: { ...this.voxelmapViewer.parameters.ao },
+                specular: { ...this.voxelmapViewer.parameters.specular },
             };
             voxelsFolder
                 .add(parameters, 'shadows')
@@ -242,6 +243,13 @@ return vec4(sampled.rgb / sampled.a, 1);
                 .name('AO strength')
                 .onChange(() => {
                     this.voxelmapViewer.parameters.ao.strength = parameters.ao.strength;
+                });
+
+            voxelsFolder
+                .add(parameters.specular, 'strength', 0, 1)
+                .name('Specular strength')
+                .onChange(() => {
+                    this.voxelmapViewer.parameters.specular.strength = parameters.specular.strength;
                 });
         }
     }

--- a/src/test/test-terrain.ts
+++ b/src/test/test-terrain.ts
@@ -86,8 +86,8 @@ class TestTerrain extends TestTerrainBase {
         });
 
         this.terrainViewer = new TerrainViewer(heightmapViewer, this.voxelmapViewer);
-        this.terrainViewer.parameters.shadows.cast = true;
-        this.terrainViewer.parameters.shadows.receive = true;
+        this.voxelmapViewer.parameters.shadows.cast = this.enableShadows;
+        this.voxelmapViewer.parameters.shadows.receive = this.enableShadows;
         // this.terrainViewer.parameters.lod.enabled = false;
         // this.terrainViewer.parameters.lod.wireframe = true;
         this.scene.add(this.terrainViewer.container);


### PR DESCRIPTION
This PR adds the possibility for each voxel material to define their shininess (in addition to the color).

The new interface is:
```ts
interface IVoxelMaterial {
    readonly color: Color;
    readonly shininess?: number;
}
```

