### PR TITLE
fix: shininess

### DIFF
--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/voxels-renderable-factory-base.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/voxels-renderable-factory-base.ts
@@ -167,7 +167,8 @@ abstract class VoxelsRenderableFactoryBase {
             textureData[4 * materialId + 1] = 255 * material.color.g;
             textureData[4 * materialId + 2] = 255 * material.color.b;
             const shininess = material.shininess ?? 0;
-            textureData[4 * materialId + 3] = (255 * shininess) / VoxelsRenderableFactoryBase.maxShininess;
+            // shininess cannot be 0 or it creates visual artifacts. Clamp it.
+            textureData[4 * materialId + 3] = Math.max(1, (255 * shininess) / VoxelsRenderableFactoryBase.maxShininess);
         });
         const texture = new THREE.DataTexture(textureData, textureWidth, textureHeight);
         texture.needsUpdate = true;


### PR DESCRIPTION
This PR fixes a bug where on certain machines,
when a voxelmaterial has a shininess equal to 0 (or no shininess specified)
then it created black visual artifacts depending on the light position.

![image](https://github.com/user-attachments/assets/6dc0567c-85d1-4749-8619-f638f15bbb68)
