### PR TITLE
Feat/allow empty chunks

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -9,9 +9,9 @@ export { BoardOverlaysHandler } from './terrain/voxelmap/board/overlay/board-ove
 export { VoxelmapWrapper } from './terrain/voxelmap/board/voxelmap-wrapper';
 export {
     voxelmapDataPacking,
-    type ILocalMapData,
     type IVoxelMap,
     type IVoxelMaterial,
+    type LocalMapData,
     type VoxelsChunkOrdering,
     type VoxelsChunkSize,
 } from './terrain/voxelmap/i-voxelmap';

--- a/src/lib/terrain/voxelmap/board/board.ts
+++ b/src/lib/terrain/voxelmap/board/board.ts
@@ -99,6 +99,9 @@ async function computeBoard(map: IVoxelMap, originWorld: THREE.Vector3Like, radi
         ) {
             throw new Error();
         }
+        if (data.isEmpty) {
+            return 0;
+        }
         const index = dataPos.x + dataPos.y * dataSize.x + dataPos.z * dataSize.x * dataSize.y;
         return data.data[index]!;
     };

--- a/src/lib/terrain/voxelmap/board/voxelmap-wrapper.ts
+++ b/src/lib/terrain/voxelmap/board/voxelmap-wrapper.ts
@@ -1,6 +1,6 @@
 import * as THREE from '../../../libs/three-usage';
 import { processAsap } from '../../../helpers/async/async-sync';
-import { voxelmapDataPacking, type ILocalMapData, type IVoxelMap, type IVoxelMaterial, type VoxelsChunkSize } from '../i-voxelmap';
+import { voxelmapDataPacking, type IVoxelMap, type IVoxelMaterial, type LocalMapData, type VoxelsChunkSize } from '../i-voxelmap';
 import { PatchId } from '../patch/patch-id';
 
 import { EBoardSquareType, type Board } from './board';
@@ -52,11 +52,15 @@ class VoxelmapWrapper implements IVoxelMap {
         this.includeBoard = includeBoard;
     }
 
-    public getLocalMapData(blockStart: THREE.Vector3Like, blockEnd: THREE.Vector3Like): ILocalMapData | Promise<ILocalMapData> {
+    public getLocalMapData(blockStart: THREE.Vector3Like, blockEnd: THREE.Vector3Like): LocalMapData | Promise<LocalMapData> {
         const blockSize = new THREE.Vector3().subVectors(blockEnd, blockStart);
 
         const originalLocalMapData = this.originGetLocalMapData(blockStart, blockEnd);
         return processAsap(originalLocalMapData, localMapData => {
+            if (localMapData.isEmpty) {
+                return localMapData;
+            }
+
             const columnWorld = { x: 0, y: 0, z: 0 };
             for (columnWorld.z = blockStart.z; columnWorld.z < blockEnd.z; columnWorld.z++) {
                 for (columnWorld.x = blockStart.x; columnWorld.x < blockEnd.x; columnWorld.x++) {

--- a/src/lib/terrain/voxelmap/i-voxelmap.ts
+++ b/src/lib/terrain/voxelmap/i-voxelmap.ts
@@ -24,24 +24,23 @@ type VoxelsChunkSize = {
 type VoxelsChunkOrdering = 'xyz' | 'xzy' | 'yxz' | 'yzx' | 'zxy' | 'zyx';
 
 /** Compact object storing a portion of the map data  */
-interface ILocalMapData {
-    /** Compact array storing the voxel data.
-     * Each element in the array represent a coordinate in the map and stores the data of the voxel at these coordinates.
-     * Each element should be encoded as follows:
-     * - bit 0: 0 if the voxel is empty, 1 otherwise
-     * - bit 1: 1 if the voxel should be displayed as checkerboard, 0 otherwise
-     * - bits 2-13: ID of the material
-     * Use the helper "voxelmapDataPacking" to do this encoding and be future-proof.
-     */
-    readonly data: Uint16Array;
-    readonly dataOrdering: VoxelsChunkOrdering;
-
-    /** Should be:
-     * - true if there are no voxels in the data
-     * - false if there is at least one voxel in the data
-     */
-    readonly isEmpty: boolean;
-}
+type LocalMapData =
+    | {
+          /** Compact array storing the voxel data.
+           * Each element in the array represent a coordinate in the map and stores the data of the voxel at these coordinates.
+           * Each element should be encoded as follows:
+           * - bit 0: 0 if the voxel is empty, 1 otherwise
+           * - bit 1: 1 if the voxel should be displayed as checkerboard, 0 otherwise
+           * - bits 2-13: ID of the material
+           * Use the helper "voxelmapDataPacking" to do this encoding and be future-proof.
+           */
+          readonly data: Uint16Array;
+          readonly dataOrdering: VoxelsChunkOrdering;
+          readonly isEmpty: false;
+      }
+    | {
+          readonly isEmpty: true;
+      };
 
 /**
  * Interface for a class storing a 3D voxel map.
@@ -62,9 +61,9 @@ interface IVoxelMap {
      * @param from Lower limit (inclusive) for the voxels coordinates
      * @param to Upper limit (exclusive) for the voxels coordinates
      */
-    getLocalMapData(from: Vector3Like, to: Vector3Like): ILocalMapData | Promise<ILocalMapData>;
+    getLocalMapData(from: Vector3Like, to: Vector3Like): LocalMapData | Promise<LocalMapData>;
 }
 
 const voxelmapDataPacking = new VoxelmapDataPacking();
 
-export { voxelmapDataPacking, type ILocalMapData, type IVoxelMap, type IVoxelMaterial, type VoxelsChunkOrdering, type VoxelsChunkSize };
+export { voxelmapDataPacking, type LocalMapData, type IVoxelMap, type IVoxelMaterial, type VoxelsChunkOrdering, type VoxelsChunkSize };

--- a/src/lib/terrain/voxelmap/patch/patch-factory/patch-factory-base.ts
+++ b/src/lib/terrain/voxelmap/patch/patch-factory/patch-factory-base.ts
@@ -91,6 +91,13 @@ abstract class PatchFactoryBase {
 
         const queriedLocalMapData = map.getLocalMapData(cacheStart, cacheEnd);
         return processAsap(queriedLocalMapData, localMapData => {
+            if (localMapData.isEmpty) {
+                return {
+                    size: cacheSize,
+                    isEmpty: true,
+                };
+            }
+
             const expectedCacheItemsCount = cacheSize.x * cacheSize.y * cacheSize.z;
             if (localMapData.data.length !== expectedCacheItemsCount) {
                 throw new Error(

--- a/src/test/map/voxel-map.ts
+++ b/src/test/map/voxel-map.ts
@@ -8,8 +8,8 @@ import {
     type IHeightmap,
     type IHeightmapCoords,
     type IHeightmapSample,
-    type ILocalMapData,
     type IVoxelMap,
+    type LocalMapData,
 } from '../../lib/index';
 
 import { colorMapping } from './color-mapping';
@@ -133,7 +133,7 @@ class VoxelMap implements IVoxelMap, IHeightmap {
         }
     }
 
-    public getLocalMapData(blockStart: THREE.Vector3, blockEnd: THREE.Vector3): ILocalMapData | Promise<ILocalMapData> {
+    public getLocalMapData(blockStart: THREE.Vector3, blockEnd: THREE.Vector3): LocalMapData | Promise<LocalMapData> {
         const blockSize = new THREE.Vector3().subVectors(blockEnd, blockStart);
         const data = new Uint16Array(blockSize.x * blockSize.y * blockSize.z);
 
@@ -224,11 +224,7 @@ class VoxelMap implements IVoxelMap, IHeightmap {
             }
         }
 
-        const result: ILocalMapData = {
-            data,
-            dataOrdering: 'zyx',
-            isEmpty,
-        };
+        const result: LocalMapData = isEmpty ? { isEmpty } : { data, dataOrdering: 'zyx', isEmpty };
 
         const synchronous = false;
         if (synchronous) {

--- a/src/test/test-physics.ts
+++ b/src/test/test-physics.ts
@@ -328,7 +328,11 @@ class TestPhysics extends TestBase {
                             const voxelsChunkData = Object.assign(patchMapData, {
                                 size: new THREE.Vector3().subVectors(blockEnd, blockStart),
                             });
-                            this.voxelmapCollider.setChunk(patchId, voxelsChunkData);
+
+                            this.voxelmapCollider.setChunk(patchId, {
+                                ...voxelsChunkData,
+                                isFull: false,
+                            });
                             await this.voxelmapViewer.enqueuePatch(patchId, voxelsChunkData);
                         }
                     },


### PR DESCRIPTION
This PR changes the `ILocalMapData` API:
- allows empty chunks to not include `data` (it was not read anyways)
- renaming from `ILocalMapData` to `LocalMapData`