### PR TITLE
Feat/emissive

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "three": ">=0.170.0"
+    "three": ">=0.172.0"
   },
   "devDependencies": {
     "@types/three": "^0.172.0",

--- a/src/lib/helpers/math.ts
+++ b/src/lib/helpers/math.ts
@@ -19,4 +19,13 @@ function safeModulo(n: number, m: number): number {
     return ((n % m) + m) % m;
 }
 
-export { nextPowerOfTwo, safeModulo };
+function clamp(x: number, min: number, max: number): number {
+    if (x < min) {
+        return min;
+    } else if (x > max) {
+        return max;
+    }
+    return x;
+}
+
+export { clamp, nextPowerOfTwo, safeModulo };

--- a/src/lib/physics/voxelmap-collisions.ts
+++ b/src/lib/physics/voxelmap-collisions.ts
@@ -1,4 +1,5 @@
 import { EVoxelStatus } from '..';
+import { clamp } from '../helpers/math';
 import * as THREE from '../libs/three-usage';
 
 import { type IVoxelmapCollider } from './i-voxelmap-collider';
@@ -59,15 +60,6 @@ type EntityCollisionOutput = {
     isOnGround: boolean;
     missingVoxels?: THREE.Vector3Like[];
 };
-
-function clamp(x: number, min: number, max: number): number {
-    if (x < min) {
-        return min;
-    } else if (x > max) {
-        return max;
-    }
-    return x;
-}
 
 function removeVoxelIdDuplicates(list: THREE.Vector3Like[]): THREE.Vector3Like[] {
     const map: Record<string, THREE.Vector3Like> = {};

--- a/src/lib/terrain/voxelmap/i-voxelmap.ts
+++ b/src/lib/terrain/voxelmap/i-voxelmap.ts
@@ -14,6 +14,7 @@ type Color = {
 interface IVoxelMaterial {
     readonly color: Color;
     readonly shininess?: number;
+    readonly emissiveness?: number;
 }
 
 type VoxelsChunkSize = {

--- a/src/test/map/color-mapping.ts
+++ b/src/test/map/color-mapping.ts
@@ -16,7 +16,13 @@ class ColorMapping {
             for (leveled.g = 0; leveled.g < this.valuesCountPerChannel; leveled.g++) {
                 for (leveled.r = 0; leveled.r < this.valuesCountPerChannel; leveled.r++) {
                     const color = this.buildColorFromLeveled(leveled);
-                    this.materialsList.push({ color, shininess: 200 * Math.random() });
+
+                    const isEmissive = Math.random() > 0.7;
+                    this.materialsList.push({
+                        color,
+                        shininess: isEmissive ? 0 : 200 * Math.random(),
+                        emissiveness: isEmissive ? 0.5 : 0,
+                    });
                 }
             }
         }

--- a/src/test/test-terrain-base.ts
+++ b/src/test/test-terrain-base.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three-usage-test';
+import GUI from 'lil-gui';
 
 import { type IHeightmap, type IHeightmapSample, type IVoxelMap, type TerrainViewer } from '../lib';
 
@@ -18,6 +19,8 @@ abstract class TestTerrainBase extends TestBase {
         readonly fakeCameraHelper: THREE.CameraHelper;
         readonly visibilityFrustum: THREE.Frustum;
     } = null;
+
+    protected readonly gui = new GUI();
 
     public constructor(voxelMap: IHeightmap & IVoxelMap & ITerrainMap) {
         super();
@@ -121,9 +124,11 @@ abstract class TestTerrainBase extends TestBase {
         dirLight.target.position.set(0, 0, 0);
         dirLight.position.set(100, 50, 100);
         this.scene.add(dirLight);
+        this.gui.add(dirLight, 'intensity', 0, 3).name('Directional light');
 
         const ambientLight = new THREE.AmbientLight(0xffffff);
         this.scene.add(ambientLight);
+        this.gui.add(ambientLight, 'intensity', 0, 3).name('Ambient light');
 
         if (this.enableShadows) {
             const planeReceivingShadows = new THREE.Mesh(new THREE.PlaneGeometry(200, 200), new THREE.MeshPhongMaterial());

--- a/src/test/test-terrain.ts
+++ b/src/test/test-terrain.ts
@@ -1,4 +1,3 @@
-import GUI from 'lil-gui';
 import * as THREE from 'three-usage-test';
 
 import {
@@ -173,7 +172,6 @@ return vec4(sampled.rgb / sampled.a, 1);
         });
         this.promisesQueue = new PromisesQueue(this.voxelmapViewer.maxPatchesComputedInParallel + 5);
 
-        const gui = new GUI();
         {
             const texturingOptions = {
                 textured: EVoxelsDisplayMode.TEXTURED,
@@ -181,7 +179,7 @@ return vec4(sampled.rgb / sampled.a, 1);
                 grey: EVoxelsDisplayMode.GREY,
             };
 
-            const voxelsFolder = gui.addFolder('Voxels');
+            const voxelsFolder = this.gui.addFolder('Voxels');
             voxelsFolder.open();
             const parameters = {
                 shadows: this.enableShadows,


### PR DESCRIPTION
This PR adds support for emissive materials.
```ts
interface IVoxelMaterial {
    readonly color: Color;
    readonly shininess?: number;
    readonly emissiveness?: number;
}
```

There is one restriction: a material cannot be both specular and emissive.