### PR TITLE
Feat/lod improvements

### DIFF
--- a/src/lib/helpers/misc.ts
+++ b/src/lib/helpers/misc.ts
@@ -27,4 +27,3 @@ function buildNoiseTexture(resolution: number): THREE.DataTexture {
 }
 
 export { buildNoiseTexture, copyMap, disableMatrixAutoupdate };
-

--- a/src/lib/helpers/misc.ts
+++ b/src/lib/helpers/misc.ts
@@ -1,4 +1,4 @@
-import type * as THREE from '../libs/three-usage';
+import * as THREE from '../libs/three-usage';
 
 function copyMap<T, U>(source: ReadonlyMap<T, U>, destination: Map<T, U>): void {
     destination.clear();
@@ -12,4 +12,19 @@ function disableMatrixAutoupdate(object: THREE.Object3D): void {
     object.matrixWorldAutoUpdate = false; // tell the parent to not always call updateMatrixWorld()
 }
 
-export { copyMap, disableMatrixAutoupdate };
+function buildNoiseTexture(resolution: number): THREE.DataTexture {
+    const textureWidth = resolution;
+    const textureHeight = resolution;
+    const textureData = new Uint8Array(textureWidth * textureHeight);
+
+    for (let i = 0; i < textureData.length; i++) {
+        textureData[i] = Math.floor(256 * Math.random());
+    }
+
+    const dataTexture = new THREE.DataTexture(textureData, textureWidth, textureHeight, THREE.RedFormat);
+    dataTexture.needsUpdate = true;
+    return dataTexture;
+}
+
+export { buildNoiseTexture, copyMap, disableMatrixAutoupdate };
+

--- a/src/lib/helpers/transition.ts
+++ b/src/lib/helpers/transition.ts
@@ -21,6 +21,10 @@ class Transition {
     }
 
     public get progress(): number {
+        if (this.duration === 0) {
+            return 1;
+        }
+
         const progress = (performance.now() - this.startTimestamp) / this.duration;
         if (progress < 0) {
             return 0;

--- a/src/lib/terrain/heightmap/atlas/heightmap-atlas.ts
+++ b/src/lib/terrain/heightmap/atlas/heightmap-atlas.ts
@@ -293,11 +293,22 @@ class HeightmapAtlas {
     }
 
     public getStatistics(): HeightmapAtlasStatistics {
-        return {
+        const result = {
             rootNodesCount: this.rootTextures.size,
             rootNodeTextureSize: this.rootTileSizeInTexels,
-            totalGpuMemoryBytes: this.rootTextures.size * (4 + 4) * this.rootTileSizeInTexels ** 2,
+            totalGpuMemoryBytes: 0,
         };
+
+        for (const rootTexture of this.rootTextures.values()) {
+            const pixelsCount = rootTexture.renderTarget.width * rootTexture.renderTarget.height;
+            let pixelSize = 4 * rootTexture.renderTarget.textures.length;
+            if (rootTexture.renderTarget.depthBuffer) {
+                pixelSize += 4;
+            }
+            result.totalGpuMemoryBytes += pixelsCount * pixelSize;
+        }
+
+        return result;
     }
 
     private hasDataForTile(tileId: AtlasTileId): boolean {

--- a/src/lib/terrain/heightmap/gpu/new/heightmap-viewer-gpu.ts
+++ b/src/lib/terrain/heightmap/gpu/new/heightmap-viewer-gpu.ts
@@ -87,19 +87,8 @@ class HeightmapViewerGpu implements IHeightmapViewer {
 
     public setHiddenPatches(patches: Iterable<PatchId>): void {
         const quadtree = new Quadtree();
-
-        this.applyVisibility(quadtree);
-
-        for (const patch of patches) {
-            const quadtreeNode = quadtree.getOrBuildNode({ nestingLevel: this.maxNesting, worldCoordsInLevel: patch });
-            quadtreeNode.setVisible(false);
-
-            for (let dX = -1; dX <= 1; dX++) {
-                for (let dZ = -1; dZ <= 1; dZ++) {
-                    quadtree.getOrBuildNode({ nestingLevel: this.maxNesting, worldCoordsInLevel: { x: patch.x + dX, z: patch.z + dZ } });
-                }
-            }
-        }
+        this.applyFocusToQuadtree(quadtree);
+        this.hideLeafsInQuatree(quadtree, patches);
 
         this.updateMeshes(quadtree);
     }
@@ -118,7 +107,7 @@ class HeightmapViewerGpu implements IHeightmapViewer {
         return result;
     }
 
-    private applyVisibility(quadtree: Quadtree): void {
+    private applyFocusToQuadtree(quadtree: Quadtree): void {
         for (const rootNode of quadtree.getRootNodes()) {
             rootNode.setVisible(false);
         }
@@ -150,6 +139,19 @@ class HeightmapViewerGpu implements IHeightmapViewer {
             for (let iZ = cellNodeFrom.y; iZ <= cellNodeTo.y; iZ++) {
                 const node = quadtree.getOrBuildNode({ nestingLevel: this.maxNesting, worldCoordsInLevel: { x: iX, z: iZ } });
                 node.setVisible(true);
+            }
+        }
+    }
+
+    private hideLeafsInQuatree(quadtree: Quadtree, patches: Iterable<PatchId>): void {
+        for (const patch of patches) {
+            const quadtreeNode = quadtree.getOrBuildNode({ nestingLevel: this.maxNesting, worldCoordsInLevel: patch });
+            quadtreeNode.setVisible(false);
+
+            for (let dX = -1; dX <= 1; dX++) {
+                for (let dZ = -1; dZ <= 1; dZ++) {
+                    quadtree.getOrBuildNode({ nestingLevel: this.maxNesting, worldCoordsInLevel: { x: patch.x + dX, z: patch.z + dZ } });
+                }
             }
         }
     }

--- a/src/lib/terrain/heightmap/gpu/new/heightmap-viewer-gpu.ts
+++ b/src/lib/terrain/heightmap/gpu/new/heightmap-viewer-gpu.ts
@@ -17,6 +17,7 @@ type HeightmapViewerGpuStatistics = {
 type Parameters = {
     readonly heightmapAtlas: HeightmapAtlas;
     readonly flatShading: boolean;
+    readonly transitionTime?: number;
     readonly garbageCollecting?: {
         readonly maxInvisibleRootTilesInCache?: number;
         readonly frequency?: number;
@@ -39,6 +40,7 @@ class HeightmapViewerGpu implements IHeightmapViewer {
     private readonly heightmapAtlas: HeightmapAtlas;
     private readonly geometryStore: TileGeometryStore;
     private readonly flatShading: boolean;
+    private readonly transitionTime: number;
 
     private get rootTileSize(): number {
         return this.heightmapAtlas.rootTileSizeInWorld;
@@ -67,6 +69,7 @@ class HeightmapViewerGpu implements IHeightmapViewer {
             altitude: params.heightmapAtlas.heightmap.altitude,
         });
         this.flatShading = params.flatShading;
+        this.transitionTime = params.transitionTime ?? 250;
 
         this.garbageCollecting = {
             maxInvisibleRootTilesInCache: params.garbageCollecting?.maxInvisibleRootTilesInCache ?? 10,
@@ -225,6 +228,7 @@ class HeightmapViewerGpu implements IHeightmapViewer {
                         heightmapAtlas: this.heightmapAtlas,
                         tileId: rootQuadtreeNode.nodeId.worldCoordsInLevel,
                         flatShading: this.flatShading,
+                        transitionTime: this.transitionTime,
                     });
                     this.container.add(rootTile.container);
                     this.rootTilesMap.set(rootTileId, rootTile);

--- a/src/lib/terrain/heightmap/gpu/new/meshes/heightmap-root-tile.ts
+++ b/src/lib/terrain/heightmap/gpu/new/meshes/heightmap-root-tile.ts
@@ -8,6 +8,7 @@ type Parameters = {
     readonly heightmapAtlas: HeightmapAtlas;
     readonly tileId: { x: number; z: number };
     readonly flatShading: boolean;
+    readonly transitionTime: number;
 };
 
 class HeightmapRootTile extends HeightmapTile {
@@ -21,6 +22,7 @@ class HeightmapRootTile extends HeightmapTile {
             },
             atlasTileId: { nestingLevel: 0, x: params.tileId.x, y: params.tileId.z },
             flatShading: params.flatShading,
+            transitionTime: params.transitionTime,
         });
     }
 

--- a/src/lib/terrain/heightmap/gpu/new/meshes/heightmap-tile.ts
+++ b/src/lib/terrain/heightmap/gpu/new/meshes/heightmap-tile.ts
@@ -197,15 +197,6 @@ vColor = texture0Sample.rgb;
                 uniform float uMinAltitude;
                 uniform float uMaxAltitude;
 
-                uniform float uDropUp;
-                uniform float uDropDown;
-                uniform float uDropLeft;
-                uniform float uDropRight;
-                uniform float uDropDownLeft;
-                uniform float uDropDownRight;
-                uniform float uDropUpLeft;
-                uniform float uDropUpRight;
-
                 out vec2 vHighPrecisionZW;
 
                 void main() {

--- a/src/lib/terrain/heightmap/gpu/new/meshes/heightmap-tile.ts
+++ b/src/lib/terrain/heightmap/gpu/new/meshes/heightmap-tile.ts
@@ -60,7 +60,9 @@ class HeightmapTile {
 
     private readonly flatShading: boolean;
 
-    private needToRequestData: boolean;
+    private hasBasicData: boolean;
+    private hasOptimalData: boolean;
+    private didRequestData: boolean = false;
 
     private subdivided: boolean = false;
     public children: Children | null = null;
@@ -90,7 +92,8 @@ class HeightmapTile {
         this.common = params.common;
         this.flatShading = params.flatShading;
 
-        this.needToRequestData = !atlasTileView.hasOptimalData();
+        this.hasBasicData = atlasTileView.hasData();
+        this.hasOptimalData = atlasTileView.hasOptimalData();
 
         const uniforms = {
             uTexture0: { value: atlasTileView.texture },
@@ -375,14 +378,15 @@ vColor = texture0Sample.rgb;
         }
 
         if (!this.subdivided) {
-            if (this.needToRequestData) {
-                if (!this.self.atlasTileView.hasOptimalData()) {
-                    this.self.atlasTileView.requestData();
-                }
-                this.needToRequestData = false;
+            this.hasOptimalData = this.hasOptimalData || this.self.atlasTileView.hasOptimalData();
+            this.hasBasicData = this.hasOptimalData || this.hasBasicData || this.self.atlasTileView.hasData();
+
+            if (!this.hasOptimalData && !this.didRequestData) {
+                this.self.atlasTileView.requestData();
+                this.didRequestData = true;
             }
 
-            if (!this.selfContainer.visible && this.self.atlasTileView.hasData()) {
+            if (!this.selfContainer.visible && this.hasBasicData) {
                 this.selfContainer.visible = true;
             }
         }

--- a/src/lib/terrain/voxelmap/viewer/voxelmap-viewer.ts
+++ b/src/lib/terrain/voxelmap/viewer/voxelmap-viewer.ts
@@ -125,7 +125,9 @@ class VoxelmapViewer extends VoxelmapViewerBase {
         let asyncChunk = this.asyncChunks.get(chunkId.asString);
         if (!asyncChunk) {
             asyncChunk = new AsyncChunkRenderable({ parent: this.container, id: chunkId, transitionTime: this.transitionTime });
-            asyncChunk.onVisibilityChange.push(() => this.notifyChange());
+            asyncChunk.onVisibilityChange.push(() => {
+                this.notifyChange();
+            });
             this.asyncChunks.set(chunkId.asString, asyncChunk);
         }
         if (!asyncChunk.needsNewData()) {
@@ -173,14 +175,15 @@ class VoxelmapViewer extends VoxelmapViewerBase {
     public setVisibility(visibleChunksIds: Iterable<THREE.Vector3Like>): void {
         const visibleChunksIdsSet = new Set<string>();
         for (const visibleChunkId of visibleChunksIds) {
-            const chunkid = new ChunkId(visibleChunkId);
-            visibleChunksIdsSet.add(chunkid.asString);
+            const chunkId = new ChunkId(visibleChunkId);
+            visibleChunksIdsSet.add(chunkId.asString);
 
-            if (!this.asyncChunks.has(chunkid.asString)) {
-                this.asyncChunks.set(
-                    chunkid.asString,
-                    new AsyncChunkRenderable({ parent: this.container, id: chunkid, transitionTime: this.transitionTime })
-                );
+            if (!this.asyncChunks.has(chunkId.asString)) {
+                const asyncChunk = new AsyncChunkRenderable({ parent: this.container, id: chunkId, transitionTime: this.transitionTime });
+                asyncChunk.onVisibilityChange.push(() => {
+                    this.notifyChange();
+                });
+                this.asyncChunks.set(chunkId.asString, asyncChunk);
             }
         }
 

--- a/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/voxels-renderable-factory-base.ts
+++ b/src/lib/terrain/voxelmap/voxelsRenderable/voxelsRenderableFactory/voxels-renderable-factory-base.ts
@@ -1,3 +1,4 @@
+import { buildNoiseTexture } from '../../../../helpers/misc';
 import { vec3ToString } from '../../../../helpers/string';
 import { type PackedUintFragment } from '../../../../helpers/uint-packing';
 import * as THREE from '../../../../libs/three-usage';
@@ -66,8 +67,7 @@ abstract class VoxelsRenderableFactoryBase {
             this.checkerboardType = params.checkerboardType;
         }
 
-        this.noiseTexture = VoxelsRenderableFactoryBase.buildNoiseTexture(this.noiseTextureSize);
-        this.noiseTexture.needsUpdate = true;
+        this.noiseTexture = buildNoiseTexture(this.noiseTextureSize);
 
         const maxVoxelTypesSupported = params.voxelTypeEncoder.maxValue + 1;
         if (params.voxelMaterialsStore.materialsCount > maxVoxelTypesSupported) {
@@ -152,18 +152,6 @@ abstract class VoxelsRenderableFactoryBase {
             uGridColor: { value: new THREE.Vector3(-0.2, -0.2, -0.2) },
             uShininessStrength: { value: 1 },
         };
-    }
-
-    private static buildNoiseTexture(resolution: number): THREE.DataTexture {
-        const textureWidth = resolution;
-        const textureHeight = resolution;
-        const textureData = new Uint8Array(textureWidth * textureHeight);
-
-        for (let i = 0; i < textureData.length; i++) {
-            textureData[i] = 256 * Math.random();
-        }
-
-        return new THREE.DataTexture(textureData, textureWidth, textureHeight, THREE.RedFormat);
     }
 }
 


### PR DESCRIPTION
This PR adds a fade-out animation for the LOD (same as for the voxels chunks).

It also optimizes the memory usage of the LOD:
- before, for a view distance of 5000, in an average scene the LOD required around 300Mo of GPU memory
- now in the same conditions, the LOD only takes around 100Mo

The memory usage could be optimized way more but it would require a lot of work, so the ROI is not great for now.