### PR TITLE
fix/fix_clutterviewer_api

### DIFF
--- a/src/lib/terrain/voxelmap/clutter/clutter-viewer.ts
+++ b/src/lib/terrain/voxelmap/clutter/clutter-viewer.ts
@@ -5,7 +5,7 @@ import { logger } from '../../../helpers/logger';
 import { vec3ToString } from '../../../helpers/string';
 import * as THREE from '../../../libs/three-usage';
 import { ChunkId } from '../chunk/chunk-id';
-import { type IClutterDefinition, type IVoxelMap, type VoxelsChunkSize } from '../i-voxelmap';
+import { type IClutterDefinition, type VoxelsChunkSize } from '../i-voxelmap';
 import { type VoxelsChunkData } from '../viewer/voxelmap-viewer';
 
 import { ClutterComputer } from './clutter-computer';
@@ -23,8 +23,8 @@ type ClutterViewerStatistics = {
 };
 
 type Parameters = {
-    readonly map: IVoxelMap;
     readonly chunkSize: VoxelsChunkSize;
+    readonly clutterVoxelsDefinitions: ReadonlyArray<IClutterDefinition>;
     readonly computationOptions:
         | {
               readonly method: 'main-thread';
@@ -68,7 +68,7 @@ class ClutterViewer {
         this.chunkSize = params.chunkSize;
         this.chunkSizeVec3 = { x: params.chunkSize.xz, y: params.chunkSize.y, z: params.chunkSize.xz };
 
-        this.propsViewers = params.map.voxelTypesDefininitions.clutterVoxels.map((clutterDefinition: IClutterDefinition, id: number) => {
+        this.propsViewers = params.clutterVoxelsDefinitions.map((clutterDefinition: IClutterDefinition, id: number) => {
             let bufferGeometry: THREE.BufferGeometry;
             let material: THREE.MeshPhongMaterial;
 

--- a/src/test/test-board.ts
+++ b/src/test/test-board.ts
@@ -70,7 +70,7 @@ class TestBoard extends TestBase {
         });
 
         this.clutterViewer = new ClutterViewer({
-            map,
+            clutterVoxelsDefinitions: map.voxelTypesDefininitions.clutterVoxels,
             chunkSize,
             computationOptions: {
                 method: 'worker',

--- a/src/test/test-physics.ts
+++ b/src/test/test-physics.ts
@@ -88,7 +88,7 @@ class TestPhysics extends TestBase {
         });
 
         this.clutterViewer = new ClutterViewer({
-            map: this.map,
+            clutterVoxelsDefinitions: this.map.voxelTypesDefininitions.clutterVoxels,
             chunkSize,
             computationOptions: {
                 method: 'worker',

--- a/src/test/test-terrain.ts
+++ b/src/test/test-terrain.ts
@@ -205,7 +205,7 @@ class TestTerrain extends TestBase {
         const maxChunkIdY = Math.floor(map.altitude.max / chunkSize.y);
 
         this.clutterViewer = new ClutterViewer({
-            map: this.map,
+            clutterVoxelsDefinitions: this.map.voxelTypesDefininitions.clutterVoxels,
             chunkSize,
             computationOptions: {
                 method: 'worker',


### PR DESCRIPTION
fix: simplify clutterviewer api
ClutterViewer doesn't actually need the whole map object, only the clutter types definitions