### PR TITLE
Perf/batch sampleheightmap queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@aresrpg/aresrpg-engine",
       "version": "2.7.8",
       "devDependencies": {
-        "@types/three": "^0.173.0",
+        "@types/three": "^0.174.0",
         "@typescript-eslint/eslint-plugin": "^8.24.1",
         "@typescript-eslint/parser": "^8.24.1",
         "@webgpu/types": "^0.1.54",
@@ -24,7 +24,7 @@
         "prettier": "^3.5.1",
         "shx": "^0.3.4",
         "simplex-noise": "^4.0.3",
-        "three": "^0.173.0",
+        "three": "^0.174.0",
         "ts-loader": "^9.5.2",
         "typescript": "^5.7.3",
         "webpack": "^5.98.0",
@@ -34,7 +34,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "three": ">=0.173.0"
+        "three": ">=0.174.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -405,9 +405,9 @@
       "license": "MIT"
     },
     "node_modules/@types/three": {
-      "version": "0.173.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.173.0.tgz",
-      "integrity": "sha512-KtNjfI/CRB6JVKIVeZM1R3GYDX2wkoV2itNcQu2j4d7qkhjGOuB+s2oF6jl9mztycDLGMtrAnJQYxInC8Bb20A==",
+      "version": "0.174.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.174.0.tgz",
+      "integrity": "sha512-De/+vZnfg2aVWNiuy1Ldu+n2ydgw1osinmiZTAn0necE++eOfsygL8JpZgFjR2uHmAPo89MkxBj3JJ+2BMe+Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5748,9 +5748,9 @@
       "license": "MIT"
     },
     "node_modules/three": {
-      "version": "0.173.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.173.0.tgz",
-      "integrity": "sha512-AUwVmViIEUgBwxJJ7stnF0NkPpZxx1aZ6WiAbQ/Qq61h6I9UR4grXtZDmO8mnlaNORhHnIBlXJ1uBxILEKuVyw==",
+      "version": "0.174.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.174.0.tgz",
+      "integrity": "sha512-p+WG3W6Ov74alh3geCMkGK9NWuT62ee21cV3jEnun201zodVF4tCE5aZa2U122/mkLRmhJJUQmLLW1BH00uQJQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "access": "public"
   },
   "peerDependencies": {
-    "three": ">=0.173.0"
+    "three": ">=0.174.0"
   },
   "devDependencies": {
-    "@types/three": "^0.173.0",
+    "@types/three": "^0.174.0",
     "@typescript-eslint/eslint-plugin": "^8.24.1",
     "@typescript-eslint/parser": "^8.24.1",
     "@webgpu/types": "^0.1.54",
@@ -42,7 +42,7 @@
     "prettier": "^3.5.1",
     "shx": "^0.3.4",
     "simplex-noise": "^4.0.3",
-    "three": "^0.173.0",
+    "three": "^0.174.0",
     "ts-loader": "^9.5.2",
     "typescript": "^5.7.3",
     "webpack": "^5.98.0",

--- a/src/lib/terrain/heightmap/atlas/heightmap-atlas.ts
+++ b/src/lib/terrain/heightmap/atlas/heightmap-atlas.ts
@@ -499,8 +499,8 @@ class HeightmapAtlas {
             const renderTarget = new THREE.WebGLRenderTarget(this.leafTileSizeInTexels, this.leafTileSizeInTexels, {
                 wrapS: THREE.ClampToEdgeWrapping,
                 wrapT: THREE.ClampToEdgeWrapping,
-                minFilter: THREE.NearestFilter,
-                magFilter: THREE.NearestFilter,
+                minFilter: THREE.LinearFilter,
+                magFilter: THREE.LinearFilter,
                 generateMipmaps: false,
                 depthBuffer: true,
                 stencilBuffer: false,

--- a/src/lib/terrain/heightmap/minimap/minimap.ts
+++ b/src/lib/terrain/heightmap/minimap/minimap.ts
@@ -399,55 +399,8 @@ class Minimap {
         const now = performance.now();
         if (now - this.texture.lastUpdateTimestamp > this.texture.updatePeriod) {
             this.texture.centerWorld = { x: this.centerPosition.x, y: this.centerPosition.z };
-            const textureCornerWorld = new THREE.Vector2().copy(this.texture.centerWorld).subScalar(0.5 * this.texture.worldSize);
-
-            const atlasLeafFrom = textureCornerWorld.clone().divideScalar(this.heightmapAtlas.leafTileSizeInWorld).floor();
-            const atlasLeafTo = textureCornerWorld
-                .clone()
-                .addScalar(this.texture.worldSize)
-                .divideScalar(this.heightmapAtlas.leafTileSizeInWorld)
-                .floor();
-            const atlasLeafId = { x: 0, y: 0 };
-            for (atlasLeafId.y = atlasLeafFrom.y; atlasLeafId.y <= atlasLeafTo.y; atlasLeafId.y++) {
-                for (atlasLeafId.x = atlasLeafFrom.x; atlasLeafId.x <= atlasLeafTo.x; atlasLeafId.x++) {
-                    const leafView = this.heightmapAtlas.getTileView({
-                        nestingLevel: this.heightmapAtlas.maxNestingLevel,
-                        ...atlasLeafId,
-                    });
-                    if (!leafView.hasOptimalData()) {
-                        leafView.requestData();
-                    }
-                }
-            }
-
-            renderer.autoClear = false;
-            renderer.sortObjects = false;
-
-            renderer.setRenderTarget(this.texture.renderTarget);
-
-            const atlasRootFrom = textureCornerWorld.clone().divideScalar(this.heightmapAtlas.rootTileSizeInWorld).floor();
-            const atlasRootTo = textureCornerWorld
-                .clone()
-                .addScalar(this.texture.worldSize)
-                .divideScalar(this.heightmapAtlas.rootTileSizeInWorld)
-                .floor();
-            const atlasRootId = { x: 0, y: 0 };
-            for (atlasRootId.y = atlasRootFrom.y; atlasRootId.y <= atlasRootTo.y; atlasRootId.y++) {
-                for (atlasRootId.x = atlasRootFrom.x; atlasRootId.x <= atlasRootTo.x; atlasRootId.x++) {
-                    const rootTileView = this.heightmapAtlas.getTileView({ nestingLevel: 0, ...atlasRootId });
-
-                    const viewport = new THREE.Vector4(
-                        (rootTileView.coords.world.origin.x - textureCornerWorld.x) / this.heightmapAtlas.texelSizeInWorld,
-                        (rootTileView.coords.world.origin.y - textureCornerWorld.y) / this.heightmapAtlas.texelSizeInWorld,
-                        this.heightmapAtlas.rootTileSizeInTexels,
-                        this.heightmapAtlas.rootTileSizeInTexels
-                    );
-                    this.texture.atlasTextureUniform.value = rootTileView.texture;
-                    this.texture.copyAtlasMaterial.uniformsNeedUpdate = true;
-                    renderer.setViewport(viewport);
-                    renderer.render(this.texture.fullscreenQuad, this.camera);
-                }
-            }
+            this.requestDataFromAtlas();
+            this.copyAtlasToLocalTexture(renderer);
             this.texture.lastUpdateTimestamp = now;
         }
 
@@ -570,6 +523,66 @@ class Minimap {
             marker.object3D.removeFromParent();
             this.markers.map.delete(name);
         }
+    }
+
+    private requestDataFromAtlas(): void {
+        const textureCornerWorld = this.textureCornerWorld;
+
+        const atlasLeafFrom = textureCornerWorld.clone().divideScalar(this.heightmapAtlas.leafTileSizeInWorld).floor();
+        const atlasLeafTo = textureCornerWorld
+            .clone()
+            .addScalar(this.texture.worldSize)
+            .divideScalar(this.heightmapAtlas.leafTileSizeInWorld)
+            .floor();
+        const atlasLeafId = { x: 0, y: 0 };
+        for (atlasLeafId.y = atlasLeafFrom.y; atlasLeafId.y <= atlasLeafTo.y; atlasLeafId.y++) {
+            for (atlasLeafId.x = atlasLeafFrom.x; atlasLeafId.x <= atlasLeafTo.x; atlasLeafId.x++) {
+                const leafView = this.heightmapAtlas.getTileView({
+                    nestingLevel: this.heightmapAtlas.maxNestingLevel,
+                    ...atlasLeafId,
+                });
+                if (!leafView.hasOptimalData()) {
+                    leafView.requestData();
+                }
+            }
+        }
+    }
+
+    private copyAtlasToLocalTexture(renderer: THREE.WebGLRenderer): void {
+        const textureCornerWorld = this.textureCornerWorld;
+
+        renderer.autoClear = false;
+        renderer.sortObjects = false;
+
+        renderer.setRenderTarget(this.texture.renderTarget);
+
+        const atlasRootFrom = textureCornerWorld.clone().divideScalar(this.heightmapAtlas.rootTileSizeInWorld).floor();
+        const atlasRootTo = textureCornerWorld
+            .clone()
+            .addScalar(this.texture.worldSize)
+            .divideScalar(this.heightmapAtlas.rootTileSizeInWorld)
+            .floor();
+        const atlasRootId = { x: 0, y: 0 };
+        for (atlasRootId.y = atlasRootFrom.y; atlasRootId.y <= atlasRootTo.y; atlasRootId.y++) {
+            for (atlasRootId.x = atlasRootFrom.x; atlasRootId.x <= atlasRootTo.x; atlasRootId.x++) {
+                const rootTileView = this.heightmapAtlas.getTileView({ nestingLevel: 0, ...atlasRootId });
+
+                const viewport = new THREE.Vector4(
+                    (rootTileView.coords.world.origin.x - textureCornerWorld.x) / this.heightmapAtlas.texelSizeInWorld,
+                    (rootTileView.coords.world.origin.y - textureCornerWorld.y) / this.heightmapAtlas.texelSizeInWorld,
+                    this.heightmapAtlas.rootTileSizeInTexels,
+                    this.heightmapAtlas.rootTileSizeInTexels
+                );
+                this.texture.atlasTextureUniform.value = rootTileView.texture;
+                this.texture.copyAtlasMaterial.uniformsNeedUpdate = true;
+                renderer.setViewport(viewport);
+                renderer.render(this.texture.fullscreenQuad, this.camera);
+            }
+        }
+    }
+
+    private get textureCornerWorld(): THREE.Vector2 {
+        return new THREE.Vector2().copy(this.texture.centerWorld).subScalar(0.5 * this.texture.worldSize);
     }
 }
 

--- a/src/test/test-terrain.ts
+++ b/src/test/test-terrain.ts
@@ -534,8 +534,12 @@ return vec4(sampled.rgb / sampled.a, 1);
         this.minimap.setMarker('origin', new THREE.Vector3(0, 142, 0));
 
         this.heightmapAtlas.update(this.renderer);
-        this.minimap.update(this.renderer);
-        this.clutterViewer.update(this.camera, this.playerSphere.position.clone().add({ x: 0, y: 1, z: 0 }));
+        if (this.params.minimap.enabled) {
+            this.minimap.update(this.renderer);
+        }
+        if (this.clutterViewer.container.visible) {
+            this.clutterViewer.update(this.camera, this.playerSphere.position.clone().add({ x: 0, y: 1, z: 0 }));
+        }
     }
 
     protected override render(): void {

--- a/src/test/test-terrain.ts
+++ b/src/test/test-terrain.ts
@@ -281,11 +281,15 @@ class TestTerrain extends TestBase {
             heightmapAtlas: this.heightmapAtlas,
             compassTexture: new THREE.TextureLoader().load('resources/compass.png'),
             meshPrecision: 64,
+            heightmapAtlasDownscalingFactor: 2,
             minViewDistance: 100,
             maxViewDistance: 750,
             markersSize: 0.05,
             waterData: this.waterData,
         });
+        this.minimap.viewDistance = 500;
+        this.minimap.verticalAngle = 1;
+        this.minimap.crustThickness = 0.025;
 
         if (!(map as VoxelMap).includeTreesInLod) {
             const perPatch = new Map<string, THREE.Vector3Like[]>();

--- a/src/test/test-terrain.ts
+++ b/src/test/test-terrain.ts
@@ -177,6 +177,10 @@ class TestTerrain extends TestBase {
 
         this.heightmapAtlas = new HeightmapAtlas({
             heightmap: map,
+            heightmapQueries: {
+                interval: 200,
+                batching: 2,
+            },
             materialsStore: this.voxelMaterialsStore,
             texelSizeInWorld: 2,
             leafTileSizeInWorld: 64,

--- a/src/test/test-terrain.ts
+++ b/src/test/test-terrain.ts
@@ -76,6 +76,9 @@ class TestTerrain extends TestBase {
     } | null = null;
 
     private readonly params = {
+        voxels: {
+            viewRadius: 10,
+        },
         minimap: {
             enabled: true,
         },
@@ -109,10 +112,6 @@ class TestTerrain extends TestBase {
                 );
             }, 0);
         } else {
-            const viewParams = {
-                playerViewRadius: 10,
-            };
-
             const playerContainer = new THREE.Group();
             playerContainer.name = 'player-container';
             playerContainer.position.x = 0;
@@ -170,12 +169,10 @@ class TestTerrain extends TestBase {
             setInterval(() => {
                 this.showMapAroundPosition(
                     playerContainer.position,
-                    viewParams.playerViewRadius,
+                    this.params.voxels.viewRadius,
                     this.playerVisibility?.visibilityFrustum ?? undefined
                 );
             }, 200);
-
-            this.gui.add(viewParams, 'playerViewRadius', 1, 1000, 1);
         }
 
         this.heightmapAtlas = new HeightmapAtlas({
@@ -394,6 +391,7 @@ return vec4(sampled.rgb / sampled.a, 1);
                 specular: { ...this.voxelmapViewer.parameters.specular },
             };
             voxelsFolder.add(this.voxelmapViewer.container, 'visible').name('Show voxels');
+            voxelsFolder.add(this.params.voxels, 'viewRadius', 1, 1000, 1).name('View distance');
             voxelsFolder
                 .add(parameters, 'shadows')
                 .name('Enable shadows')


### PR DESCRIPTION
This PR tries to optimize calls to the `sampleHeightmap` API by:
- adding a parameter to the `Minimap`to reduce its quality (= fewer queries necessary)
- adding a parameter to the `HeightmapAtlas` to group queries together (= batch them by 4 for example)

Also updates three to 0.174.0.

Also fixes a visual bug where some LOD tiles where very square.