### PR TITLE
fix: emissive voxel materials looked darker than normal on HeightmapAtlas

### DIFF
--- a/src/lib/terrain/heightmap/atlas/heightmap-atlas.ts
+++ b/src/lib/terrain/heightmap/atlas/heightmap-atlas.ts
@@ -219,7 +219,7 @@ class HeightmapAtlas {
                 void main() {
                     gl_Position = vec4(2.0 * position - 1.0, uLevelUniform / ${(maxNestingLevel + 1).toFixed(1)}, 1);
 
-                    vColor = getVoxelMaterial(materialId, uMaterialsTexture, 0.0).color;
+                    vColor = getVoxelColor(materialId, uMaterialsTexture);
 
                     const float minAltitude = ${params.altitude.min.toFixed(1)};
                     const float maxAltitude = ${params.altitude.max.toFixed(1)};

--- a/src/lib/terrain/heightmap/gpu/meshes/heightmap-root-texture.ts
+++ b/src/lib/terrain/heightmap/gpu/meshes/heightmap-root-texture.ts
@@ -192,7 +192,7 @@ class HeightmapRootTexture {
             
             void main() {
                 gl_Position = vec4(2.0 * position.xz - 1.0, 1.0 - uNestingLevel / 200.0, 1);
-                vColor = getVoxelMaterial(materialId, uMaterialsTexture, 0.0).color;
+                vColor = getVoxelColor(materialId, uMaterialsTexture);
                 vAltitude = (altitude - uMinAltitude) / (uMaxAltitude - uMinAltitude);
             }
             `,

--- a/src/lib/terrain/materials-store.ts
+++ b/src/lib/terrain/materials-store.ts
@@ -57,6 +57,12 @@ struct VoxelMaterial {
     vec3 emissive;
 };
 
+vec3 getVoxelColor(const in uint materialId, const in sampler2D materialsTexture) {
+    ivec2 texelCoords = ivec2(materialId % ${this.texture.image.width}u, materialId / ${this.texture.image.width}u);
+    vec4 fetchedTexel = texelFetch(materialsTexture, texelCoords, 0);
+    return fetchedTexel.rgb;
+}
+
 VoxelMaterial getVoxelMaterial(const in uint materialId, const in sampler2D materialsTexture, float noise) {
     VoxelMaterial voxelMaterial;
     ivec2 texelCoords = ivec2(materialId % ${this.texture.image.width}u, materialId / ${this.texture.image.width}u);

--- a/src/test/map/color-mapping.ts
+++ b/src/test/map/color-mapping.ts
@@ -17,7 +17,7 @@ class ColorMapping {
                 for (leveled.r = 0; leveled.r < this.valuesCountPerChannel; leveled.r++) {
                     const color = this.buildColorFromLeveled(leveled);
 
-                    const isEmissive = false; // Math.random() > 0.7;
+                    const isEmissive = Math.random() > 0.7;
                     this.materialsList.push({
                         color,
                         shininess: isEmissive ? 0 : 200 * Math.random(),


### PR DESCRIPTION
Fixes a bug where voxel materials that had some emissiveness were not displayed correctly in Minimap or HeightmapViewer.
With this PR, they are better displayed. A bug remains where the HeightmapViewer colors are not emissive, but fixing it would hurt performance a bit so I would rather not do it.

Example on a "laval" material that is orange and very emissive:
Before:
![image](https://github.com/user-attachments/assets/3cd61438-f2cd-4296-a3ee-e8efd0cc02c3)
After:
![image](https://github.com/user-attachments/assets/90d189a2-9616-4059-8b97-bdde61b486bc)
