### PR TITLE
fix: highdpi support

### DIFF
--- a/src/lib/helpers/misc.ts
+++ b/src/lib/helpers/misc.ts
@@ -34,4 +34,24 @@ function range(from: number, toExclusive: number): number[] {
     return result;
 }
 
-export { buildNoiseTexture, copyMap, disableMatrixAutoupdate, range };
+function setViewportInvariantScalars(renderer: THREE.WebGLRenderer, x: number, y: number, width: number, height: number): void {
+    const pixelRatio = renderer.getPixelRatio();
+    renderer.setViewport(x / pixelRatio, y / pixelRatio, width / pixelRatio, height / pixelRatio);
+}
+function setViewportInvariantVec4(renderer: THREE.WebGLRenderer, viewport: THREE.Vector4): void {
+    const pixelRatio = renderer.getPixelRatio();
+    renderer.setViewport(viewport.clone().divideScalar(pixelRatio));
+}
+function setViewportWholeRendertarget(renderer: THREE.WebGLRenderer, rendertarget: THREE.WebGLRenderTarget): void {
+    setViewportInvariantScalars(renderer, 0, 0, rendertarget.width, rendertarget.height);
+}
+
+export {
+    buildNoiseTexture,
+    copyMap,
+    disableMatrixAutoupdate,
+    range,
+    setViewportInvariantScalars,
+    setViewportInvariantVec4,
+    setViewportWholeRendertarget,
+};

--- a/src/lib/terrain/heightmap/atlas/heightmap-atlas.ts
+++ b/src/lib/terrain/heightmap/atlas/heightmap-atlas.ts
@@ -1,6 +1,7 @@
 import { createFullscreenQuad } from '../../../helpers/fullscreen-quad';
 import { logger } from '../../../helpers/logger';
 import { safeModulo } from '../../../helpers/math';
+import { setViewportInvariantVec4, setViewportWholeRendertarget } from '../../../helpers/misc';
 import * as THREE from '../../../libs/three-usage';
 import type { MaterialsStore } from '../../materials-store';
 import type { HeightmapSamples } from '../i-heightmap';
@@ -340,7 +341,7 @@ class HeightmapAtlas {
 
             if (!tileLocalInfos.rootTexture.hasBeenClearedOnce) {
                 renderer.setClearColor(0x000000, 0);
-                renderer.setViewport(0, 0, tileLocalInfos.rootTexture.renderTarget.width, tileLocalInfos.rootTexture.renderTarget.height);
+                setViewportWholeRendertarget(renderer, tileLocalInfos.rootTexture.renderTarget);
                 renderer.clear(true, true);
                 tileLocalInfos.rootTexture.hasBeenClearedOnce = true;
             }
@@ -350,9 +351,9 @@ class HeightmapAtlas {
             }
 
             if (tileLocalInfos.rootTexture.isStub) {
-                renderer.setViewport(0, 0, tileLocalInfos.rootTexture.renderTarget.width, tileLocalInfos.rootTexture.renderTarget.height);
+                setViewportWholeRendertarget(renderer, tileLocalInfos.rootTexture.renderTarget);
             } else {
-                renderer.setViewport(tileLocalInfos.textureUv.clone().multiplyScalar(this.rootTileSizeInTexels));
+                setViewportInvariantVec4(renderer, tileLocalInfos.textureUv.clone().multiplyScalar(this.rootTileSizeInTexels));
             }
 
             this.tileGrid.materialIdAttribute.array.set(pendingUpdate.heightmapSamples.materialIds);
@@ -657,7 +658,7 @@ class HeightmapAtlas {
         renderer.setRenderTarget(this.textureExpansion.renderTarget);
         this.textureExpansion.textureUniform.value = atlasTexture.renderTarget.texture;
         this.textureExpansion.fullscreenQuad.material = this.textureExpansion.copyMaterial;
-        renderer.setViewport(0, 0, this.textureExpansion.renderTarget.width, this.textureExpansion.renderTarget.height);
+        setViewportWholeRendertarget(renderer, this.textureExpansion.renderTarget);
         renderer.render(this.textureExpansion.fullscreenQuad, this.fakeCamera);
 
         atlasTexture.renderTarget.setSize(this.rootTileSizeInTexels, this.rootTileSizeInTexels);
@@ -665,7 +666,7 @@ class HeightmapAtlas {
         renderer.setRenderTarget(atlasTexture.renderTarget);
         this.textureExpansion.textureUniform.value = this.textureExpansion.renderTarget.texture;
         this.textureExpansion.fullscreenQuad.material = this.textureExpansion.copyMaterial;
-        renderer.setViewport(0, 0, atlasTexture.renderTarget.width, atlasTexture.renderTarget.height);
+        setViewportWholeRendertarget(renderer, atlasTexture.renderTarget);
         renderer.render(this.textureExpansion.fullscreenQuad, this.fakeCamera);
 
         atlasTexture.isStub = false;

--- a/src/lib/terrain/heightmap/gpu/meshes/heightmap-root-texture.ts
+++ b/src/lib/terrain/heightmap/gpu/meshes/heightmap-root-texture.ts
@@ -1,4 +1,5 @@
 import { createFullscreenQuad } from '../../../../helpers/fullscreen-quad';
+import { setViewportInvariantScalars } from '../../../../helpers/misc';
 import * as THREE from '../../../../libs/three-usage';
 import { type MaterialsStore } from '../../../materials-store';
 import { type HeightmapSamples } from '../../i-heightmap';
@@ -271,7 +272,8 @@ class HeightmapRootTexture {
         }
 
         const uvChunk = this.getTileUv(tileId);
-        renderer.setViewport(
+        setViewportInvariantScalars(
+            renderer,
             uvChunk.shift.x * this.rawRendertarget.width,
             uvChunk.shift.y * this.rawRendertarget.height,
             uvChunk.scale * this.rawRendertarget.width,

--- a/src/lib/terrain/heightmap/minimap/minimap.ts
+++ b/src/lib/terrain/heightmap/minimap/minimap.ts
@@ -1,5 +1,6 @@
 import { createFullscreenQuad } from '../../../helpers/fullscreen-quad';
 import { clamp } from '../../../helpers/math';
+import { setViewportInvariantVec4 } from '../../../helpers/misc';
 import * as THREE from '../../../libs/three-usage';
 import { type WaterData } from '../../water/water-data';
 import type { HeightmapAtlas, HeightmapAtlasTileView } from '../atlas/heightmap-atlas';
@@ -644,7 +645,7 @@ class Minimap {
                 );
                 this.texture.atlasTextureUniform.value = rootTileView.texture;
                 this.texture.copyAtlasMaterial.uniformsNeedUpdate = true;
-                renderer.setViewport(viewport);
+                setViewportInvariantVec4(renderer, viewport);
                 renderer.render(this.texture.fullscreenQuad, this.camera);
             }
         }

--- a/src/test/test-base.ts
+++ b/src/test/test-base.ts
@@ -38,6 +38,7 @@ abstract class TestBase {
         this.renderer = new THREE.WebGLRenderer();
         document.body.appendChild(this.renderer.domElement);
         this.renderer.setClearColor(0x880000);
+        this.renderer.setPixelRatio(window.devicePixelRatio);
 
         this.camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 10000);
         const udpateRendererSize = () => {


### PR DESCRIPTION
FIxes a bug where the HeightmapAtlas had invalid data on screens that had `window.devicePixelRatio !== 1`.

This is because the pixelRatio provided to the renderer via `WebGLRenderer.setPixelRatio()` is applied to all viewports set via `WebGLRenderer.setViewport()`, even if the rendertarget is an offscreen texture which size is dpi-independent
