### PR TITLE
fix: HeightmapViewer was incorrectly frustum culled

### DIFF
--- a/src/lib/terrain/heightmap/gpu/meshes/heightmap-tile.ts
+++ b/src/lib/terrain/heightmap/gpu/meshes/heightmap-tile.ts
@@ -2,7 +2,7 @@ import { Transition } from '../../../../helpers/transition';
 import type * as THREE from '../../../../libs/three-usage';
 import type { AtlasTileId, HeightmapAtlas, HeightmapAtlasTileView } from '../../atlas/heightmap-atlas';
 
-import { type EdgesResolution, EEdgeResolution, type TileGeometryStore } from './tile-geometry-store';
+import { type EdgesResolution, EEdgeResolution } from './tile-geometry-store';
 
 type Children = {
     readonly mm: HeightmapTile;
@@ -19,7 +19,6 @@ type InstancedAttributesHandle = {
 type Parameters = {
     readonly common: {
         readonly heightmapAtlas: HeightmapAtlas;
-        readonly geometryStore: TileGeometryStore;
         getInstancedAttributesHandle(): InstancedAttributesHandle;
     };
     readonly atlasTileId: AtlasTileId;


### PR DESCRIPTION
This PR fixes a bug where the HeightmapViewer was sometimes not displayed. This was due to the bounding box and sphere that were not updated as often as needed on the `InstancedMesh`.